### PR TITLE
If the X-Hub-Signature header isn't present, fail the secrets check.

### DIFF
--- a/snare
+++ b/snare
@@ -39,6 +39,8 @@ class HookHandler(BaseHTTPRequestHandler):
             self.send_response(501)
 
     def _check_secret(self, data):
+        if "X-Hub-Signature" not in self.headers:
+            return false
         sha, sig = self.headers["X-Hub-Signature"].split("=")
         mac = hmac.new(secret.encode(), msg=data, digestmod=hashlib.sha1)
         return hmac.compare_digest(mac.hexdigest(), sig)


### PR DESCRIPTION
Without this, we ran into exception when we tried to read this header. Since we don't want to let people not specify secrets, failing is the right thing to do.