### PR TITLE
Always run per-repo programs in a temporary directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ where:
  * `<repo-programs-dir>` is the directory where the per-repo programs are
    stored. For a repository `repo` owned by `user` the command
    `<repo-programs-dir>/<user>/<repo> <event> <path to GitHub JSON>` will be
-   run.
+   run. Note that per-repo programs are run with their current working
+   directory set to a temporary directory to which they can freely write and
+   which will be automatically removed when they have completed.
  * `<secrets-path>` is the file containing the GitHub secret which guarantees
    that hooks are coming from your GitHub repository and not a malfeasant. Note
    that leading and trailing whitespace in this file is ignored.

--- a/snare
+++ b/snare
@@ -27,10 +27,11 @@ class HookHandler(BaseHTTPRequestHandler):
 
         path = os.path.join(repo_scripts_dir, owner, repo)
         if os.path.exists(path):
-            with tempfile.NamedTemporaryFile() as jsonf:
-                jsonf.write(data_str.encode())
-                event = self.headers["X-GitHub-Event"]
-                rtn = subprocess.run([path, event, jsonf.name])
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with tempfile.NamedTemporaryFile() as jsonf:
+                    jsonf.write(data_str.encode())
+                    event = self.headers["X-GitHub-Event"]
+                    rtn = subprocess.run([path, event, jsonf.name], cwd=tmpdir)
             if rtn.returncode == 0:
                 self.send_response(200)
             else:


### PR DESCRIPTION
It seems likely that nearly all per-repo programs will want to write something to disk (at the very least cloning a repository), so running them in a temporary directory (which is automatically cleaned up after the program exits) makes the programs a little less error prone and a little easier to write.