### PR TITLE
Use SecStr to make it a bit harder to access the GitHub secret.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ mio = "0.6"
 nix = "0.16"
 num_cpus = "1.12"
 percent-encoding = "2.1"
+secstr = "0.3"
 sha-1 = "0.8"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["full"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use getopts::Options;
+use secstr::SecStr;
 
 pub struct Config {
     /// The maximum number of parallel jobs to run.
@@ -16,7 +17,7 @@ pub struct Config {
     /// A *fully canonicalised* path to the directory containing per-repo programs.
     pub reposdir: String,
     /// The GitHub secret used to validate requests.
-    pub secret: String,
+    pub secret: SecStr,
     /// An optional email address to send errors to.
     pub email: Option<String>,
 }
@@ -85,10 +86,13 @@ impl Config {
                 .opt_str("s")
                 .unwrap_or_else(|| error("A secrets path must be specified."));
             let path = Path::new(p);
-            read_to_string(path)
-                .unwrap_or_else(|_| error("Couldn't read secrets file."))
-                .trim()
-                .to_owned()
+            SecStr::new(
+                read_to_string(path)
+                    .unwrap_or_else(|_| error("Couldn't read secrets file."))
+                    .trim()
+                    .to_owned()
+                    .into_bytes(),
+            )
         };
 
         Config {

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -106,7 +106,7 @@ async fn authenticate(req: Request<Body>, snare: &Arc<Snare>) -> Result<Bytes, (
         .map_err(|_| ())?;
 
     // Verify that this request was signed by the same secret that we have.
-    let mut mac = Hmac::<Sha1>::new_varkey(snare.config.secret.as_bytes()).map_err(|_| ())?;
+    let mut mac = Hmac::<Sha1>::new_varkey(snare.config.secret.unsecure()).map_err(|_| ())?;
     mac.input(&*data);
     mac.verify(&hex::decode(sig).map_err(|_| ())?)
         .map_err(|_| ())?;


### PR DESCRIPTION
If someone manages to break into snare, this raises the bar for them to access the GitHub secret.