### PR TITLE
Move to using a configuration file.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,21 @@ version = "0.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 edition = "2018"
 
+[build-dependencies]
+cfgrammar = "0.5"
+lrlex = "0.5"
+lrpar = "0.5"
+
 [dependencies]
+cfgrammar = "0.5"
 getopts = "0.2"
 hex = "0.4"
 hmac = "0.7"
 hyper = "0.13"
 json = "0.12"
 lettre = "0.9"
+lrlex = "0.5"
+lrpar = "0.5"
 mio = "0.6"
 nix = "0.16"
 num_cpus = "1.12"
@@ -19,6 +27,7 @@ secstr = "0.3"
 sha-1 = "0.8"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["full"] }
+users = "0.9"
 whoami = "0.7"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -7,32 +7,55 @@ can then perform whatever actions it wants.
 
 ## Basic usage
 
-`snare` requires three command-line arguments to be specified:
+`snare` has the following command-line format:
 
 ```
-Usage: snare [-e email] [-j <max-jobs>] -p <port> -r <repos-dir> -s <secrets-path>
+Usage: snare [-c <config-path>]
 ```
 
 where:
 
- * `<email>` is an (optional) email address to which any errors running per-repo
-   programs will be sent (warning: full stderr/stdout will be sent, so consider
-   carefully whether these have sensitive information or not).
- * `<max-jobs>` is an (optional) non-zero integer specifying the maximum number
-   of jobs to run in parallel.
- * `<port>` is a port number (e.g. 4567).
- * `<repo-programs-dir>` is the directory where the per-repo programs are
-   stored. For a repository `repo` owned by `user` the command
-   `<repo-programs-dir>/<user>/<repo> <event> <path to GitHub JSON>` will be
-   run. Note that per-repo programs are run with their current working
-   directory set to a temporary directory to which they can freely write and
-   which will be automatically removed when they have completed.
- * `<secrets-path>` is the file containing the GitHub secret which guarantees
-   that hooks are coming from your GitHub repository and not a malfeasant. Note
-   that leading and trailing whitespace in this file is ignored.
+ * `<config-path>` is a path to a `snare.conf` configuration file. If not
+   specified explicitly, the following locations will be searched, in order:
+     * `/etc/snare.conf/`
+     * `~/.snare.conf`
 
-The most important part of this are the per-repo programs. For example,
-`snare`'s GitHub repository is
+
+## Configuration file
+
+The configuration file supports the following options:
+
+ * `email = "<address>"` optionally specifies an email address to which any
+   errors running per-repo programs will be sent (warning: full stderr/stdout
+   will be sent, so consider carefully whether these have sensitive information
+   or not).
+ * `maxjobs = <int>` is an (optional) non-zero integer specifying the maximum
+   number of jobs to run in parallel. Defaults to the number of CPUs in the
+   machine.
+ * `port = <int>` is a mandatory port number to listen on (e.g. 4567).
+ * `reposdir = "<path>"` is the directory where the per-repo programs are
+   stored. For a repository `repo` owned by `user` the command
+   `<reposdir>/<user>/<repo> <event> <path to GitHub JSON>` will be run. Note
+   that per-repo programs are run with their current working directory set to a
+   temporary directory to which they can freely write and which will be
+   automatically removed when they have completed.
+ * `secret = "<secret>"` is the mandatory GitHub secret which guarantees that
+   hooks are coming from your GitHub repository and not a malfeasant.
+
+The minimal configuration file is thus:
+
+```
+port = <port>
+reposdir = "<path>"
+secret = "<secret>"
+```
+
+
+## Per-repo programs
+
+When using snare, the *per-repo programs* do the actual work of executing
+specific actions for a given repository.  For example, `snare`'s GitHub
+repository is
 [`https://github.com/softdevteam/snare`](https://github.com/softdevteam/snare).
 If we set up a web hook up for that repository that notifies us of pull request
 events, then the command:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+use cfgrammar::yacc::YaccKind;
+use lrlex::LexerBuilder;
+use lrpar::CTParserBuilder;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new_with_storaget()
+        .yacckind(YaccKind::Grmtools)
+        .process_file_in_src("config.y")?;
+    LexerBuilder::new()
+        .rule_ids_map(lex_rule_ids_map)
+        .process_file_in_src("config.l")?;
+
+    Ok(())
+}

--- a/src/config.l
+++ b/src/config.l
@@ -1,0 +1,11 @@
+%%
+[0-9]+ "INT"
+"(?:\\\\|\\"|[^"])*" "STRING"
+= "="
+email "EMAIL"
+maxjobs "MAXJOBS"
+port "PORT"
+reposdir "REPOSDIR"
+secret "SECRET"
+//.*? ;
+[ \t\n\r]* ;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,26 @@ use std::{
     env,
     fs::{canonicalize, read_to_string},
     io::{stderr, Write},
-    path::Path,
+    path::{Path, PathBuf},
     process,
 };
 
 use getopts::Options;
+use lrlex::lrlex_mod;
+use lrpar::{lrpar_mod, Lexeme, Lexer};
 use secstr::SecStr;
+use users::{get_current_uid, get_user_by_uid, os::unix::UserExt};
+
+use crate::{fatal, fatal_err};
+
+lrlex_mod!("config.l");
+lrpar_mod!("config.y");
+
+type StorageT = u8;
+
+/// Default locations to look for `snare.conf`: `~/` will be automatically converted to the current
+/// user's home directory.
+const SNARE_CONF_SEARCH: &[&str] = &["/etc/snare.conf", "~/.snare.conf"];
 
 pub struct Config {
     /// The maximum number of parallel jobs to run.
@@ -28,16 +42,7 @@ impl Config {
         let args: Vec<String> = env::args().collect();
         let prog = &args[0];
         let matches = Options::new()
-            .optmulti("e", "email", "Email address to send errors to", "<email>")
-            .optmulti(
-                "j",
-                "maxjobs",
-                "Maximum number of jobs to run at once",
-                "<maxjobs>",
-            )
-            .optmulti("p", "port", "Port to listen on", "<port>")
-            .optmulti("r", "reposdir", "Directory of per-repo programs", "<port>")
-            .optmulti("s", "secretspath", "Path to secrets", "<path>")
+            .optmulti("c", "config", "Path to snare.conf.", "<path>")
             .optflag("h", "help", "")
             .parse(&args[1..])
             .unwrap_or_else(|_| usage(prog));
@@ -45,70 +50,146 @@ impl Config {
             usage(prog);
         }
 
-        let email = matches.opt_str("e");
+        let conf_path = match matches.opt_str("c") {
+            Some(p) => PathBuf::from(&p),
+            None => search_snare_conf().unwrap_or_else(|| fatal("Can't find snare.conf")),
+        };
+        let input = match read_to_string(conf_path) {
+            Ok(s) => s,
+            Err(e) => fatal_err("Can't read configuration file", e),
+        };
 
-        let maxjobs = matches
-            .opt_str("j")
-            .map(|x| {
-                x.parse()
-                    .unwrap_or_else(|_| error("Invalid number of jobs."))
-            })
-            .unwrap_or_else(num_cpus::get);
-        if maxjobs == 0 {
-            error("Must allow at least 1 job.");
-        } else if maxjobs == std::usize::MAX {
-            error(&format!(
-                "Maximum number of jobs is {}.",
-                std::usize::MAX - 1
-            ));
+        let lexerdef = config_l::lexerdef();
+        let lexer = lexerdef.lexer(&input);
+        let (astopt, errs) = config_y::parse(&lexer);
+        for e in &errs {
+            eprintln!("{}", e.pp(&lexer, &config_y::token_epp));
+        }
+        let mut email = None;
+        let mut port = None;
+        let mut maxjobs = None;
+        let mut reposdir = None;
+        let mut secret = None;
+        match astopt {
+            Some(Ok(opts)) => {
+                for opt in opts {
+                    match opt {
+                        GenericOption::Email(lexeme) => {
+                            if email.is_some() {
+                                conf_fatal(
+                                    &lexer,
+                                    lexeme,
+                                    "Mustn't specify 'email' more than once",
+                                );
+                            }
+                            let email_str = lexer.lexeme_str(&lexeme);
+                            let email_str = &email_str[1..email_str.len() - 1];
+                            email = Some(email_str.to_owned());
+                        }
+                        GenericOption::MaxJobs(lexeme) => {
+                            if maxjobs.is_some() {
+                                conf_fatal(
+                                    &lexer,
+                                    lexeme,
+                                    "Mustn't specify 'maxjobs' more than once",
+                                );
+                            }
+                            let maxjobs_str = lexer.lexeme_str(&lexeme);
+                            match maxjobs_str.parse() {
+                                Ok(0) => conf_fatal(&lexer, lexeme, "Must allow at least 1 job"),
+                                Ok(x) if x == std::usize::MAX => conf_fatal(
+                                    &lexer,
+                                    lexeme,
+                                    &format!("Maximum number of jobs is {}", std::usize::MAX - 1),
+                                ),
+                                Ok(x) => maxjobs = Some(x),
+                                Err(e) => conf_fatal(&lexer, lexeme, &format!("{}", e)),
+                            }
+                        }
+                        GenericOption::Port(lexeme) => {
+                            if port.is_some() {
+                                conf_fatal(&lexer, lexeme, "Mustn't specify 'port' more than once");
+                            }
+                            let port_str = lexer.lexeme_str(&lexeme);
+                            port = Some(port_str.parse().unwrap_or_else(|_| {
+                                conf_fatal(&lexer, lexeme, &format!("Invalid port '{}'", port_str))
+                            }));
+                        }
+                        GenericOption::ReposDir(lexeme) => {
+                            if reposdir.is_some() {
+                                conf_fatal(
+                                    &lexer,
+                                    lexeme,
+                                    "Mustn't specify 'reposdir' more than once",
+                                );
+                            }
+
+                            let reposdir_str = lexer.lexeme_str(&lexeme);
+                            let reposdir_str = &reposdir_str[1..reposdir_str.len() - 1];
+                            reposdir = Some(match canonicalize(reposdir_str) {
+                                Ok(p) => match p.to_str() {
+                                    Some(s) => s.to_owned(),
+                                    None => fatal(&format!(
+                                        "'{}': can't convert to string",
+                                        &reposdir_str
+                                    )),
+                                },
+                                Err(e) => {
+                                    fatal_err(&format!("'{}'", reposdir_str), e);
+                                }
+                            });
+                        }
+                        GenericOption::Secret(lexeme) => {
+                            if secret.is_some() {
+                                conf_fatal(
+                                    &lexer,
+                                    lexeme,
+                                    "Mustn't specify 'secret' more than once",
+                                );
+                            }
+                            let secret_str = lexer.lexeme_str(&lexeme);
+                            let secret_str = &secret_str[1..secret_str.len() - 1];
+                            secret = Some(SecStr::from(secret_str));
+                        }
+                    }
+                }
+            }
+            _ => process::exit(1),
+        }
+        if maxjobs.is_none() {
+            maxjobs = Some(num_cpus::get());
+        }
+        if port.is_none() {
+            fatal("A port must be specified");
+        }
+        if reposdir.is_none() {
+            fatal("A directory for per-repo programs must be specified");
+        }
+        if secret.is_none() {
+            fatal("A secret must be specified");
         }
 
-        let port = matches
-            .opt_str("p")
-            .map(|x| x.parse().unwrap_or_else(|_| error("Invalid port.")))
-            .unwrap_or_else(|| error("A port must be specified."));
-
-        let reposdir_str = matches
-            .opt_str("r")
-            .unwrap_or_else(|| error("A directory for per-repo programs must be specified."));
-        let reposdir = match canonicalize(&reposdir_str) {
-            Ok(p) => match p.to_str() {
-                Some(s) => s.to_owned(),
-                None => error(&format!("{}: can't convert to string", &reposdir_str)),
-            },
-            Err(e) => {
-                error(&format!("{}: {}", &reposdir_str, e));
-            }
-        };
-
-        let secret = {
-            let p = &matches
-                .opt_str("s")
-                .unwrap_or_else(|| error("A secrets path must be specified."));
-            let path = Path::new(p);
-            SecStr::new(
-                read_to_string(path)
-                    .unwrap_or_else(|_| error("Couldn't read secrets file."))
-                    .trim()
-                    .to_owned()
-                    .into_bytes(),
-            )
-        };
-
         Config {
-            maxjobs,
-            port,
-            reposdir,
-            secret,
+            maxjobs: maxjobs.unwrap(),
+            port: port.unwrap(),
+            reposdir: reposdir.unwrap(),
+            secret: secret.unwrap(),
             email,
         }
     }
 }
 
-/// Exit immediately with a message indicating the reason.
-fn error(msg: &str) -> ! {
-    writeln!(&mut stderr(), "{}", msg).ok();
-    process::exit(1)
+/// Exit with a fatal error message pinpointing `lexeme` as the culprit.
+fn conf_fatal(lexer: &dyn Lexer<StorageT>, lexeme: Lexeme<StorageT>, msg: &str) -> ! {
+    let (line_off, col) = lexer.line_col(lexeme.start());
+    let line = lexer.surrounding_line_str(lexeme.start());
+    fatal(&format!(
+        "Line {}, column {}:\n  {}\n{}",
+        line_off,
+        col,
+        line.trim(),
+        msg
+    ));
 }
 
 /// Print out program usage then exit.
@@ -125,4 +206,34 @@ fn usage(prog: &str) -> ! {
     )
     .ok();
     process::exit(1)
+}
+
+/// Try to find a `snare.conf` file.
+fn search_snare_conf() -> Option<PathBuf> {
+    for cnd in SNARE_CONF_SEARCH {
+        if cnd.starts_with("~/") {
+            let mut homedir =
+                match get_user_by_uid(get_current_uid()).map(|x| x.home_dir().to_path_buf()) {
+                    Some(p) => p,
+                    None => continue,
+                };
+            homedir.push(&cnd[2..]);
+            if homedir.is_file() {
+                return Some(homedir);
+            }
+        }
+        let p = PathBuf::from(cnd);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+pub enum GenericOption<StorageT> {
+    Email(Lexeme<StorageT>),
+    MaxJobs(Lexeme<StorageT>),
+    Port(Lexeme<StorageT>),
+    ReposDir(Lexeme<StorageT>),
+    Secret(Lexeme<StorageT>),
 }

--- a/src/config.y
+++ b/src/config.y
@@ -1,0 +1,37 @@
+%start Options
+%avoid_insert "INT" "STRING"
+
+%%
+
+Options -> Result<Vec<GenericOption<StorageT>>, ()>:
+    Options Option { flattenr($1, $2) }
+  | { Ok(vec![]) }
+  ;
+
+Option -> Result<GenericOption<StorageT>, ()>:
+    "EMAIL" "=" "STRING" { Ok(GenericOption::Email(map_err($3)?)) }
+  | "MAXJOBS" "=" "INT" { Ok(GenericOption::MaxJobs(map_err($3)?)) }
+  | "PORT" "=" "INT" { Ok(GenericOption::Port(map_err($3)?)) }
+  | "REPOSDIR" "=" "STRING" { Ok(GenericOption::ReposDir(map_err($3)?)) }
+  | "SECRET" "=" "STRING" { Ok(GenericOption::Secret(map_err($3)?)) }
+  ;
+
+%%
+use lrpar::Lexeme;
+
+use crate::config::GenericOption;
+
+type StorageT = u8;
+
+fn map_err<StorageT>(r: Result<Lexeme<StorageT>, Lexeme<StorageT>>)
+    -> Result<Lexeme<StorageT>, ()>
+{
+    r.map_err(|_| ())
+}
+
+/// Flatten `rhs` into `lhs`.
+fn flattenr<T>(lhs: Result<Vec<T>, ()>, rhs: Result<T, ()>) -> Result<Vec<T>, ()> {
+    let mut flt = lhs?;
+    flt.push(rhs?);
+    Ok(flt)
+}

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -8,7 +8,7 @@ use json;
 use percent_encoding::percent_decode;
 use sha1::Sha1;
 
-use crate::{fatal, queue::QueueJob, Snare};
+use crate::{fatal_err, queue::QueueJob, Snare};
 
 pub(crate) async fn serve(server: hyper::server::Builder<AddrIncoming>, snare: Arc<Snare>) {
     let make_svc = make_service_fn(|_| {
@@ -17,7 +17,7 @@ pub(crate) async fn serve(server: hyper::server::Builder<AddrIncoming>, snare: A
     });
 
     if let Err(e) = server.serve(make_svc).await {
-        fatal("Couldn't start HTTP server", e);
+        fatal_err("Couldn't start HTTP server", e);
     }
 }
 


### PR DESCRIPTION
At the moment, the amount of command-line switches we have is just about bearable, but this is likely to change profoundly in the future. This commit thus moves to a model of a simple configuration file.

@vext01 A question for you. My plan is for the next PR to move to a config format where you can start specifying this:

```
github {
  match "*" {
    timeout = 60
    secret = "..."
  }

  match "user/repor" {
    timeout = 600
  }
}
```

i.e. something like PF where user can specify different settings per-repo, and that happens by matching the config file from top to bottom with "last matching setting wins".

Given the curly brackets (which seem the best way of specifying this config), would it be more idiomatic to have statements end with a semi-colon `;`? I can't quite make up my mind.