### PR TITLE
Reload config after sighup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ percent-encoding = "2.1"
 regex = "1.3"
 secstr = "0.3"
 sha-1 = "0.8"
+signal-hook = "0.1"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["full"] }
 users = "0.9"

--- a/src/config.l
+++ b/src/config.l
@@ -14,5 +14,5 @@ queue "QUEUE"
 reposdir "REPOSDIR"
 secret "SECRET"
 timeout "TIMEOUT"
-//.*? ;
+//.*?$ ;
 [ \t\n\r]* ;

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
 
 impl Config {
     /// Create a `Config` from `path`.
-    pub fn from_path(conf_path: PathBuf) -> Self {
+    pub fn from_path(conf_path: &PathBuf) -> Self {
         let input = match read_to_string(conf_path) {
             Ok(s) => s,
             Err(e) => fatal_err("Can't read configuration file", e),

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use secstr::SecStr;
 use sha1::Sha1;
 
-use crate::{config_ast, fatal, fatal_err};
+use crate::{config_ast, fatal};
 
 type StorageT = u8;
 
@@ -29,18 +29,23 @@ pub struct Config {
 }
 
 impl Config {
-    /// Create a `Config` from `path`.
-    pub fn from_path(conf_path: &PathBuf) -> Self {
+    /// Create a `Config` from `path`, returning `Err(String)` (containing a human readable
+    /// message) if it was unable to do so.
+    pub fn from_path(conf_path: &PathBuf) -> Result<Self, String> {
         let input = match read_to_string(conf_path) {
             Ok(s) => s,
-            Err(e) => fatal_err("Can't read configuration file", e),
+            Err(e) => return Err(format!("Can't read {:?}: {}", conf_path, e)),
         };
 
         let lexerdef = config_l::lexerdef();
         let lexer = lexerdef.lexer(&input);
         let (astopt, errs) = config_y::parse(&lexer);
-        for e in &errs {
-            eprintln!("{}", e.pp(&lexer, &config_y::token_epp));
+        if !errs.is_empty() {
+            let msgs = errs
+                .iter()
+                .map(|e| e.pp(&lexer, &config_y::token_epp))
+                .collect::<Vec<_>>();
+            return Err(msgs.join("\n"));
         }
         let mut github = None;
         let mut port = None;
@@ -51,42 +56,66 @@ impl Config {
                     match opt {
                         config_ast::TopLevelOption::GitHub(lexeme, options, matches) => {
                             if github.is_some() {
-                                conf_fatal(
+                                return Err(error_at_lexeme(
                                     &lexer,
                                     lexeme,
                                     "Mustn't specify 'github' more than once",
-                                );
+                                ));
                             }
-                            github = Some(GitHub::parse(&lexer, options, matches));
+                            github = Some(GitHub::parse(&lexer, options, matches)?);
                         }
                         config_ast::TopLevelOption::MaxJobs(lexeme) => {
                             if maxjobs.is_some() {
-                                conf_fatal(
+                                return Err(error_at_lexeme(
                                     &lexer,
                                     lexeme,
                                     "Mustn't specify 'maxjobs' more than once",
-                                );
+                                ));
                             }
                             let maxjobs_str = lexer.lexeme_str(&lexeme);
                             match maxjobs_str.parse() {
-                                Ok(0) => conf_fatal(&lexer, lexeme, "Must allow at least 1 job"),
-                                Ok(x) if x == std::usize::MAX => conf_fatal(
-                                    &lexer,
-                                    lexeme,
-                                    &format!("Maximum number of jobs is {}", std::usize::MAX - 1),
-                                ),
+                                Ok(0) => {
+                                    return Err(error_at_lexeme(
+                                        &lexer,
+                                        lexeme,
+                                        "Must allow at least 1 job",
+                                    ))
+                                }
+                                Ok(x) if x > (std::usize::MAX - 1) / 2 => {
+                                    return Err(error_at_lexeme(
+                                        &lexer,
+                                        lexeme,
+                                        &format!(
+                                            "Maximum number of jobs is {}",
+                                            (std::usize::MAX - 1) / 2
+                                        ),
+                                    ))
+                                }
                                 Ok(x) => maxjobs = Some(x),
-                                Err(e) => conf_fatal(&lexer, lexeme, &format!("{}", e)),
+                                Err(e) => {
+                                    return Err(error_at_lexeme(&lexer, lexeme, &format!("{}", e)))
+                                }
                             }
                         }
                         config_ast::TopLevelOption::Port(lexeme) => {
                             if port.is_some() {
-                                conf_fatal(&lexer, lexeme, "Mustn't specify 'port' more than once");
+                                return Err(error_at_lexeme(
+                                    &lexer,
+                                    lexeme,
+                                    "Mustn't specify 'port' more than once",
+                                ));
                             }
                             let port_str = lexer.lexeme_str(&lexeme);
-                            port = Some(port_str.parse().unwrap_or_else(|_| {
-                                conf_fatal(&lexer, lexeme, &format!("Invalid port '{}'", port_str))
-                            }));
+                            port = Some(match port_str.parse() {
+                                Ok(p) => p,
+                                Err(_) => {
+                                    return Err(error_at_lexeme(
+                                        &lexer,
+                                        lexeme,
+                                        &format!("Invalid port '{}'", port_str),
+                                    ))
+                                }
+                            });
                         }
                     }
                 }
@@ -97,17 +126,19 @@ impl Config {
             maxjobs = Some(num_cpus::get());
         }
         if port.is_none() {
-            fatal("A port must be specified");
+            return Err("A port must be specified".to_owned());
         }
         if github.is_none() {
-            fatal("A GitHub block with at least a 'repodirs' option must be specified.");
+            return Err(
+                "A GitHub block with at least a 'repodirs' option must be specified".to_owned(),
+            );
         }
 
-        Config {
+        Ok(Config {
             maxjobs: maxjobs.unwrap(),
             port: port.unwrap(),
             github: github.unwrap(),
-        }
+        })
     }
 }
 
@@ -122,7 +153,7 @@ impl GitHub {
         lexer: &dyn Lexer<StorageT>,
         options: Vec<config_ast::ProviderOption<StorageT>>,
         ast_matches: Vec<config_ast::Match<StorageT>>,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let mut reposdir = None;
         let mut matches = vec![Match::default()];
 
@@ -130,7 +161,11 @@ impl GitHub {
             match option {
                 config_ast::ProviderOption::ReposDir(lexeme) => {
                     if reposdir.is_some() {
-                        conf_fatal(lexer, lexeme, "Mustn't specify 'reposdir' more than once");
+                        return Err(error_at_lexeme(
+                            lexer,
+                            lexeme,
+                            "Mustn't specify 'reposdir' more than once",
+                        ));
                     }
 
                     let reposdir_str = lexer.lexeme_str(&lexeme);
@@ -138,10 +173,12 @@ impl GitHub {
                     reposdir = Some(match canonicalize(reposdir_str) {
                         Ok(p) => match p.to_str() {
                             Some(s) => s.to_owned(),
-                            None => fatal(&format!("'{}': can't convert to string", &reposdir_str)),
+                            None => {
+                                return Err(format!("'{}': can't convert to string", &reposdir_str))
+                            }
                         },
                         Err(e) => {
-                            fatal_err(&format!("'{}'", reposdir_str), e);
+                            return Err(format!("'{}': {}", reposdir_str, e));
                         }
                     });
                 }
@@ -151,16 +188,27 @@ impl GitHub {
         for m in ast_matches {
             let re_str = lexer.lexeme_str(&m.re);
             let re_str = format!("^{}$", &re_str[1..re_str.len() - 1]);
-            let re = Regex::new(&re_str).unwrap_or_else(|e| {
-                conf_fatal(lexer, m.re, &format!("Regular expression error: {}", e))
-            });
+            let re = match Regex::new(&re_str) {
+                Ok(re) => re,
+                Err(e) => {
+                    return Err(error_at_lexeme(
+                        lexer,
+                        m.re,
+                        &format!("Regular expression error: {}", e),
+                    ))
+                }
+            };
             let mut email = None;
             let mut secret = None;
             for opt in m.options {
                 match opt {
                     config_ast::PerRepoOption::Email(lexeme) => {
                         if email.is_some() {
-                            conf_fatal(lexer, lexeme, "Mustn't specify 'email' more than once");
+                            return Err(error_at_lexeme(
+                                lexer,
+                                lexeme,
+                                "Mustn't specify 'email' more than once",
+                            ));
                         }
                         let email_str = lexer.lexeme_str(&lexeme);
                         let email_str = &email_str[1..email_str.len() - 1];
@@ -168,7 +216,11 @@ impl GitHub {
                     }
                     config_ast::PerRepoOption::Secret(lexeme) => {
                         if secret.is_some() {
-                            conf_fatal(lexer, lexeme, "Mustn't specify 'secret' more than once");
+                            return Err(error_at_lexeme(
+                                lexer,
+                                lexeme,
+                                "Mustn't specify 'secret' more than once",
+                            ));
                         }
                         let sec_str = lexer.lexeme_str(&lexeme);
                         let sec_str = &sec_str[1..sec_str.len() - 1];
@@ -180,7 +232,11 @@ impl GitHub {
                         match Hmac::<Sha1>::new_varkey(sec_str.as_bytes()) {
                             Ok(_) => (),
                             Err(InvalidKeyLength) => {
-                                conf_fatal(lexer, lexeme, "Invalid secret key length")
+                                return Err(error_at_lexeme(
+                                    lexer,
+                                    lexeme,
+                                    "Invalid secret key length",
+                                ))
                             }
                         }
                         secret = Some(SecStr::from(sec_str));
@@ -193,7 +249,7 @@ impl GitHub {
         let reposdir = reposdir
             .unwrap_or_else(|| fatal("A directory for per-repo programs must be specified"));
 
-        GitHub { reposdir, matches }
+        Ok(GitHub { reposdir, matches })
     }
 
     /// Return a `RepoConfig` for `owner/repo`. Note that if the user reloads the config later,
@@ -239,17 +295,17 @@ impl Default for Match {
     }
 }
 
-/// Exit with a fatal error message pinpointing `lexeme` as the culprit.
-fn conf_fatal(lexer: &dyn Lexer<StorageT>, lexeme: Lexeme<StorageT>, msg: &str) -> ! {
+/// Return an error message pinpointing `lexeme` as the culprit.
+fn error_at_lexeme(lexer: &dyn Lexer<StorageT>, lexeme: Lexeme<StorageT>, msg: &str) -> String {
     let (line_off, col) = lexer.line_col(lexeme.start());
     let line = lexer.surrounding_line_str(lexeme.start());
-    fatal(&format!(
+    format!(
         "Line {}, column {}:\n  {}\n{}",
         line_off,
         col,
         line.trim(),
         msg
-    ));
+    )
 }
 
 /// The configuration for a given repository.

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -24,8 +24,6 @@ pub(crate) async fn serve(server: hyper::server::Builder<AddrIncoming>, snare: A
 }
 
 async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>, Infallible> {
-    snare.check_for_hup();
-
     let mut res = Response::new(Body::empty());
     let req_time = Instant::now();
     let event_type = match req.headers().get("X-GitHub-Event") {

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -24,6 +24,8 @@ pub(crate) async fn serve(server: hyper::server::Builder<AddrIncoming>, snare: A
 }
 
 async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>, Infallible> {
+    snare.check_for_hup();
+
     let mut res = Response::new(Body::empty());
     let req_time = Instant::now();
     let event_type = match req.headers().get("X-GitHub-Event") {

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -58,8 +58,8 @@ async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>,
     };
 
     // If the unwrap() on the lock fails, the other thread has paniced.
-    let config = snare.config.lock().unwrap();
-    let (rconf, secret) = config.github.repoconfig(&owner, &repo);
+    let conf = snare.conf.lock().unwrap();
+    let (rconf, secret) = conf.github.repoconfig(&owner, &repo);
 
     if !authenticate(secret, sig, pl) {
         *res.status_mut() = StatusCode::UNAUTHORIZED;
@@ -69,12 +69,12 @@ async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>,
     // We now check that there is a per-repo program for this repository and that we haven't been
     // tricked into searching for a file outside of the repos dir.
     let mut p = PathBuf::new();
-    p.push(&config.github.reposdir);
+    p.push(&conf.github.reposdir);
     p.push(owner);
     p.push(repo);
     if let Ok(p) = p.canonicalize() {
         if let Some(s) = p.to_str() {
-            if s.starts_with(&config.github.reposdir) {
+            if s.starts_with(&conf.github.reposdir) {
                 // We can tolerate the `unwrap` call below because if it fails it means that
                 // something has gone so seriously wrong in the other thread that there's no
                 // likelihood that we can recover.

--- a/src/jobrunner.rs
+++ b/src/jobrunner.rs
@@ -28,7 +28,7 @@ const WAIT_TIMEOUT: i32 = 1;
 struct JobRunner {
     snare: Arc<Snare>,
     /// The maximum number of jobs we will run at any one point. Note that this may not necessarily
-    /// be the same value as snare.config.maxjobs.
+    /// be the same value as snare.conf.maxjobs.
     maxjobs: usize,
     /// The running jobs, with `0..num_running` entries.
     running: Vec<Option<Job>>,
@@ -44,8 +44,8 @@ struct JobRunner {
 impl JobRunner {
     fn new(snare: Arc<Snare>) -> Result<Self, Box<dyn Error>> {
         // If the unwrap() on the lock fails, the other thread has paniced.
-        let maxjobs = snare.config.lock().unwrap().maxjobs;
-        assert!(maxjobs < std::usize::MAX);
+        let maxjobs = snare.conf.lock().unwrap().maxjobs;
+        assert!(maxjobs <= (std::usize::MAX - 1) / 2);
         let mut running = Vec::with_capacity(maxjobs);
         running.resize_with(maxjobs, || None);
         let mut pollfds = Vec::with_capacity(maxjobs * 2 + 1);

--- a/src/jobrunner.rs
+++ b/src/jobrunner.rs
@@ -82,6 +82,11 @@ impl JobRunner {
             };
             poll(&mut self.pollfds, timeout).ok();
 
+            // The SIGHUP listener writes to the event FD if SIGHUP has been received, so it's
+            // possible that the reason we've been woken up is that the SIGHUP event needs to be
+            // processed.
+            self.snare.check_for_hup();
+
             // See if any of our active jobs have events. Knowing when a pipe is actually closed is
             // surprisingly hard. https://www.greenend.org.uk/rjk/tech/poll.html has an interesting
             // suggestion which we adapt slightly here.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use config::Config;
 use queue::Queue;
 
 pub(crate) struct Snare {
-    config: Config,
+    config: Mutex<Config>,
     queue: Mutex<Queue>,
     event_read_fd: RawFd,
     event_write_fd: RawFd,
@@ -57,7 +57,7 @@ pub async fn main() {
 
     let (event_read_fd, event_write_fd) = pipe2(OFlag::O_NONBLOCK).unwrap();
     let snare = Arc::new(Snare {
-        config,
+        config: Mutex::new(config),
         queue: Mutex::new(Queue::new()),
         event_read_fd,
         event_write_fd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ impl Snare {
     /// Check to see if we've received a SIGHUP since the last check. If so, we will reload the
     /// config file. **Note that because snare has multiple threads, the config file can change at
     /// any arbitrary point, not just after calling this function.**
-    fn check_for_hup(&self) {
+    fn check_for_sighup(&self) {
         if self.sighup_occurred.load(Ordering::Relaxed) {
             match Config::from_path(&self.conf_path) {
                 Ok(config) => *self.config.lock().unwrap() = config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,19 +13,28 @@ mod jobrunner;
 mod queue;
 
 use std::{
+    env,
     error::Error,
     fmt::Display,
+    io::{stderr, Write},
     net::SocketAddr,
     os::unix::io::RawFd,
+    path::{Path, PathBuf},
     process,
     sync::{Arc, Mutex},
 };
 
+use getopts::Options;
 use hyper::Server;
 use nix::{fcntl::OFlag, unistd::pipe2};
+use users::{get_current_uid, get_user_by_uid, os::unix::UserExt};
 
 use config::Config;
 use queue::Queue;
+
+/// Default locations to look for `snare.conf`: `~/` will be automatically converted to the current
+/// user's home directory.
+const SNARE_CONF_SEARCH: &[&str] = &["/etc/snare.conf", "~/.snare.conf"];
 
 pub(crate) struct Snare {
     config: Mutex<Config>,
@@ -46,9 +55,63 @@ fn fatal_err<E: Into<Box<dyn Error>> + Display>(msg: &str, err: E) -> ! {
     fatal(&format!("{}: {}", msg, err));
 }
 
+/// Try to find a `snare.conf` file.
+fn search_snare_conf() -> Option<PathBuf> {
+    for cnd in SNARE_CONF_SEARCH {
+        if cnd.starts_with("~/") {
+            let mut homedir =
+                match get_user_by_uid(get_current_uid()).map(|x| x.home_dir().to_path_buf()) {
+                    Some(p) => p,
+                    None => continue,
+                };
+            homedir.push(&cnd[2..]);
+            if homedir.is_file() {
+                return Some(homedir);
+            }
+        }
+        let p = PathBuf::from(cnd);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Print out program usage then exit.
+fn usage(prog: &str) -> ! {
+    let path = Path::new(prog);
+    let leaf = path
+        .file_name()
+        .map(|x| x.to_str().unwrap_or("snare"))
+        .unwrap_or("snare");
+    writeln!(
+        &mut stderr(),
+        "Usage: {} [-e email] [-j <max-jobs>] -p <port> -r <repos-dir> -s <secrets-path>",
+        leaf
+    )
+    .ok();
+    process::exit(1)
+}
+
 #[tokio::main]
 pub async fn main() {
-    let config = Config::new();
+    let args: Vec<String> = env::args().collect();
+    let prog = &args[0];
+    let matches = Options::new()
+        .optmulti("c", "config", "Path to snare.conf.", "<path>")
+        .optflag("h", "help", "")
+        .parse(&args[1..])
+        .unwrap_or_else(|_| usage(prog));
+    if matches.opt_present("h") {
+        usage(prog);
+    }
+
+    let conf_path = match matches.opt_str("c") {
+        Some(p) => PathBuf::from(&p),
+        None => search_snare_conf().unwrap_or_else(|| fatal("Can't find snare.conf")),
+    };
+    let config = Config::from_path(conf_path);
+
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     let server = match Server::try_bind(&addr) {
         Ok(s) => s,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,12 +3,14 @@ use std::{
     time::Instant,
 };
 
+use crate::config::RepoConfig;
+
 pub(crate) struct QueueJob {
     pub path: String,
     pub req_time: Instant,
     pub event_type: String,
     pub json_str: String,
-    pub email: Option<String>,
+    pub rconf: RepoConfig,
 }
 
 impl QueueJob {
@@ -17,14 +19,14 @@ impl QueueJob {
         req_time: Instant,
         event_type: String,
         json_str: String,
-        email: Option<String>,
+        rconf: RepoConfig,
     ) -> Self {
         QueueJob {
             path,
             req_time,
             event_type,
             json_str,
-            email,
+            rconf,
         }
     }
 }


### PR DESCRIPTION
This PR enables snare to reload its config on SIGHUP. This is a bit more involved than it first seems because snare is multi-threaded. This PR thus goes through several stages (putting `Config` behind a `Mutex` and so on), before actually handling SIGHUP. Note that one case is handled somewhat, but not perfectly: reducing the value of `maxjobs`. I could do more here, but I think this is a niche case, and it's hard to test: the basic approach in this PR seems decent enough to me for the time being.