### PR TITLE
Queue kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ A `match` block supports the following options:
    errors running per-repo programs will be sent (warning: full stderr/stdout
    will be sent, so consider carefully whether these have sensitive information
    or not).
+ * `queue = <parallel|sequential>` optionally specifies what to do when
+   multiple requests for the same repository are queued at once:
+     * `parallel`: run as many jobs for this repository in parallel as
+       possible.
+     * `sequential`: only run one job for this repository at a time. Additional
+       jobs will stay on the queue and be executed in FIFO order.
  * `secret = "<secret>"` is an optional GitHub secret which guarantees that
    hooks are coming from your GitHub repository and not a malfeasant. Although
    this is optional, we *highly* recommend setting it in all cases.
@@ -66,17 +72,21 @@ before any user `match` blocks:
 
 ```
 match ".*" {
+  queue = sequential
   timeout = 3600
 }
 ```
 
-The minimal configuration file is thus:
+The minimal recommended configuration file is thus:
 
 ```
 port = <port>
 
 github {
   reposdir = "<path>"
+  match ".*" {
+    email = "<email>"
+  }
 }
 ```
 
@@ -102,10 +112,12 @@ github {
 then the repositories will have the following settings:
 
   * `a/b`:
+    * `queue = sequential`
     * `timeout = 3600`
     * `email = "ghi@jkl.com"`
     * `secret = "sec"`
   * `c/d`:
+    * `queue = sequential`
     * `timeout = 3600`
     * `email = "abc@def.com"`
     * `secret = "sec"`

--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ A `match` block supports the following options:
    errors running per-repo programs will be sent (warning: full stderr/stdout
    will be sent, so consider carefully whether these have sensitive information
    or not).
- * `queue = <parallel|sequential>` optionally specifies what to do when
+ * `queue = <evict|parallel|sequential>` optionally specifies what to do when
    multiple requests for the same repository are queued at once:
+     * `evict`: only run one job for this repository at a time. Additional jobs
+       will stay on the queue: if a new job comes in for that repository, it
+       evicts any previously queued jobs for that repository. In other words,
+       for this repository there can be at most one running job and one queued
+       job at any point.
      * `parallel`: run as many jobs for this repository in parallel as
        possible.
      * `sequential`: only run one job for this repository at a time. Additional

--- a/src/config.l
+++ b/src/config.l
@@ -5,6 +5,7 @@
 \{ "{"
 \} "}"
 email "EMAIL"
+evict "EVICT"
 github "GITHUB"
 match "MATCH"
 maxjobs "MAXJOBS"

--- a/src/config.l
+++ b/src/config.l
@@ -13,6 +13,7 @@ port "PORT"
 queue "QUEUE"
 reposdir "REPOSDIR"
 secret "SECRET"
+sequential "SEQUENTIAL"
 timeout "TIMEOUT"
 //.*?$ ;
 [ \t\n\r]* ;

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,7 @@ impl GitHub {
                             ));
                         }
                         queuekind = Some(match qkind {
+                            config_ast::QueueKind::Evict => QueueKind::Evict,
                             config_ast::QueueKind::Parallel => QueueKind::Parallel,
                             config_ast::QueueKind::Sequential => QueueKind::Sequential,
                         });
@@ -382,6 +383,7 @@ pub struct RepoConfig {
 
 #[derive(Clone, Copy)]
 pub enum QueueKind {
+    Evict,
     Parallel,
     Sequential,
 }

--- a/src/config.y
+++ b/src/config.y
@@ -51,14 +51,23 @@ PerRepoOptions -> Result<Vec<PerRepoOption<StorageT>>, ()>:
 
 PerRepoOption -> Result<PerRepoOption<StorageT>, ()>:
     "EMAIL" "=" "STRING" { Ok(PerRepoOption::Email(map_err($3)?)) }
+  | "QUEUE" "=" QueueKind {
+        let (lexeme, qkind) = $3?;
+        Ok(PerRepoOption::Queue(lexeme, qkind))
+    }
   | "SECRET" "=" "STRING" { Ok(PerRepoOption::Secret(map_err($3)?)) }
   | "TIMEOUT" "=" "INT" { Ok(PerRepoOption::Timeout(map_err($3)?)) }
+  ;
+
+QueueKind -> Result<(Lexeme<StorageT>, QueueKind), ()>:
+    "PARALLEL" { Ok((map_err($1)?, QueueKind::Parallel)) }
+  | "SEQUENTIAL" { Ok((map_err($1)?, QueueKind::Sequential)) }
   ;
 
 %%
 use lrpar::Lexeme;
 
-use crate::config_ast::{TopLevelOption, Match, PerRepoOption, ProviderOption};
+use crate::config_ast::{TopLevelOption, Match, PerRepoOption, ProviderOption, QueueKind};
 
 type StorageT = u8;
 

--- a/src/config.y
+++ b/src/config.y
@@ -60,7 +60,8 @@ PerRepoOption -> Result<PerRepoOption<StorageT>, ()>:
   ;
 
 QueueKind -> Result<(Lexeme<StorageT>, QueueKind), ()>:
-    "PARALLEL" { Ok((map_err($1)?, QueueKind::Parallel)) }
+    "EVICT" { Ok((map_err($1)?, QueueKind::Evict)) }
+  | "PARALLEL" { Ok((map_err($1)?, QueueKind::Parallel)) }
   | "SEQUENTIAL" { Ok((map_err($1)?, QueueKind::Sequential)) }
   ;
 

--- a/src/config_ast.rs
+++ b/src/config_ast.rs
@@ -21,6 +21,12 @@ pub struct Match<StorageT> {
 
 pub enum PerRepoOption<StorageT> {
     Email(Lexeme<StorageT>),
+    Queue(Lexeme<StorageT>, QueueKind),
     Secret(Lexeme<StorageT>),
     Timeout(Lexeme<StorageT>),
+}
+
+pub enum QueueKind {
+    Parallel,
+    Sequential,
 }

--- a/src/config_ast.rs
+++ b/src/config_ast.rs
@@ -27,6 +27,7 @@ pub enum PerRepoOption<StorageT> {
 }
 
 pub enum QueueKind {
+    Evict,
     Parallel,
     Sequential,
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@ use std::{
     time::Instant,
 };
 
-use crate::config::RepoConfig;
+use crate::config::{QueueKind, RepoConfig};
 
 pub(crate) struct QueueJob {
     pub path: String,
@@ -67,8 +67,14 @@ impl Queue {
             .push_front(qj);
     }
 
-    /// If the queue has one or more entries, pop one and return it, or `None` otherwise.
-    pub fn pop(&mut self) -> Option<QueueJob> {
+    /// If the queue has a runnable entry, pop and return it, or `None` otherwise. Note that `None`
+    /// does not guarantee that the queue is empty: it may mean that there are queued jobs that
+    /// can't be run until existing jobs finish. `running(path)` is a function which must return
+    /// `true` if a job at `path` is currently running and `false` otherwise.
+    pub fn pop<F>(&mut self, running: F) -> Option<QueueJob>
+    where
+        F: Fn(&str) -> bool,
+    {
         // We find the oldest element in the queue and pop that.
         let mut earliest_time = None;
         let mut earliest_key = None;
@@ -77,6 +83,14 @@ impl Queue {
                 if let Some(et) = earliest_time {
                     if et > qj.req_time {
                         continue;
+                    }
+                }
+                match qj.rconf.queuekind {
+                    QueueKind::Parallel => (),
+                    QueueKind::Sequential => {
+                        if running(&qj.path) {
+                            continue;
+                        }
                     }
                 }
                 earliest_time = Some(qj.req_time);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -40,6 +40,16 @@ impl Queue {
         Queue { q: HashMap::new() }
     }
 
+    /// Are there any jobs in the queue?
+    pub fn is_empty(&self) -> bool {
+        for v in self.q.values() {
+            if !v.is_empty() {
+                return false;
+            }
+        }
+        true
+    }
+
     /// For the per-repo program at `path`, push a new request.
     pub fn push_back(&mut self, qj: QueueJob) {
         self.q


### PR DESCRIPTION
This PR adds queue kinds: `queue = <evict|parallel|sequential>`. Previously `parallel` was all we supported, which had some comic outcomes: for example, for yksom, you could get race conditions trying to force push the `gh-pages` branch. `sequential` is now the default. Hopefully the README explains why these exist and why they might be useful.

This is the last major feature I think we need before a 0.1 release (though there are a few minor bits that probably need doing).