### PR TITLE
Change the order that we search for snare.conf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ where:
 
  * `<config-path>` is a path to a `snare.conf` configuration file. If not
    specified explicitly, the following locations will be searched, in order:
-     * `/etc/snare.conf/`
      * `~/.snare.conf`
+     * `/etc/snare.conf/`
 
 
 ## Configuration file

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ use queue::Queue;
 
 /// Default locations to look for `snare.conf`: `~/` will be automatically converted to the current
 /// user's home directory.
-const SNARE_CONF_SEARCH: &[&str] = &["/etc/snare.conf", "~/.snare.conf"];
+const SNARE_CONF_SEARCH: &[&str] = &["~/.snare.conf", "/etc/snare.conf"];
 
 pub(crate) struct Snare {
     /// The location of snare.conf; this file will be reloaded if SIGHUP is received.


### PR DESCRIPTION
It makes more sense to search for the per-user .snare.conf first before falling back to trying the global /etc/snare.conf.