### PR TITLE
Daemonise by default (unless -d is passed on the command line).

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ can then perform whatever actions it wants.
 `snare` has the following command-line format:
 
 ```
-Usage: snare [-c <config-path>]
+Usage: snare [-c <config-path>] [-d]
 ```
 
 where:
 
- * `<config-path>` is a path to a `snare.conf` configuration file. If not
+ * `-c <config-path>` is a path to a `snare.conf` configuration file. If not
    specified explicitly, the following locations will be searched, in order:
      * `~/.snare.conf`
      * `/etc/snare.conf/`
+ * `-d` tells `snare` *not* to daemonise: in other words, `snare` stays in the
+   foreground. This can be useful for debugging.
 
 
 ## Configuration file

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ lrlex_mod!("config.l");
 lrpar_mod!("config.y");
 
 pub struct Config {
+    /// If true, then daemonise (i.e. disassociate from the terminal and log errors via syslog).
+    pub daemonise: bool,
     /// The IP address/port on which to listen.
     pub listen: SocketAddr,
     /// The maximum number of parallel jobs to run.
@@ -37,7 +39,7 @@ pub struct Config {
 impl Config {
     /// Create a `Config` from `path`, returning `Err(String)` (containing a human readable
     /// message) if it was unable to do so.
-    pub fn from_path(conf_path: &PathBuf) -> Result<Self, String> {
+    pub fn from_path(conf_path: &PathBuf, daemonise: bool) -> Result<Self, String> {
         let input = match read_to_string(conf_path) {
             Ok(s) => s,
             Err(e) => return Err(format!("Can't read {:?}: {}", conf_path, e)),
@@ -155,6 +157,7 @@ impl Config {
         }
 
         Ok(Config {
+            daemonise,
             listen: listen.unwrap(),
             maxjobs: maxjobs.unwrap(),
             github: github.unwrap(),


### PR DESCRIPTION
This requires a bit of reshuffling of the main method, as something in the `[tokio::main]` setup doesn't work with `daemon` (perhaps it creates threads, as `fork` only carries the main thread over to the child process).