### PR TITLE
Force "key=value" options to be terminated with a semi-colon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ where:
 
 The configuration file supports the following top-level options:
 
- * `listen = "<address>"` is a mandatory address and port number to listen on.
+ * `listen = "<address>";` is a mandatory address and port number to listen on.
    The format of `address` is either:
      * IPv4: `x.x.x.x:port` e.g. `0.0.0.0:8765` will listen on port 8765 for
        all IPv4 addresses.
      * IPv6: "[x:x:x]:port` e.g. `[::]:8765` will listen on port 8764 for all
        IPv4 and IPv6 addresses
- * `maxjobs = <int>` is an (optional) non-zero integer specifying the maximum
+ * `maxjobs = <int>;` is an (optional) non-zero integer specifying the maximum
    number of jobs to run in parallel. Defaults to the number of CPUs in the
    machine.
- * `user = "<user-name>"` is an optional username that `snare` will try and
+ * `user = "<user-name>";` is an optional username that `snare` will try and
    change into after it has bound to a network port. Note that `snare` will
    refuse to run as `root` unless the `user` option is specified. As part of
    changing user, `snare`:
@@ -51,7 +51,7 @@ The configuration file supports the following top-level options:
 
 The `github` block supports the following options:
 
- * `reposdir = "<path>"` is the directory where the per-repo programs are
+ * `reposdir = "<path>";` is the directory where the per-repo programs are
    stored. For a repository `repo` owned by `user` the command
    `<reposdir>/<user>/<repo> <event> <path to GitHub JSON>` will be run. Note
    that per-repo programs are run with their current working directory set to a
@@ -68,11 +68,11 @@ The `github` block supports the following options:
 
 A `match` block supports the following options:
 
- * `email = "<address>"` optionally specifies an email address to which any
+ * `email = "<address>";` optionally specifies an email address to which any
    errors running per-repo programs will be sent (warning: full stderr/stdout
    will be sent, so consider carefully whether these have sensitive information
    or not).
- * `queue = <evict|parallel|sequential>` optionally specifies what to do when
+ * `queue = <evict|parallel|sequential>;` optionally specifies what to do when
    multiple requests for the same repository are queued at once:
      * `evict`: only run one job for this repository at a time. Additional jobs
        will stay on the queue: if a new job comes in for that repository, it
@@ -83,10 +83,10 @@ A `match` block supports the following options:
        possible.
      * `sequential`: only run one job for this repository at a time. Additional
        jobs will stay on the queue and be executed in FIFO order.
- * `secret = "<secret>"` is an optional GitHub secret which guarantees that
+ * `secret = "<secret>";` is an optional GitHub secret which guarantees that
    hooks are coming from your GitHub repository and not a malfeasant. Although
    this is optional, we *highly* recommend setting it in all cases.
- * `timeout = <timeout>` optionally specifies the elapsed time in seconds that
+ * `timeout = <timeout>;` optionally specifies the elapsed time in seconds that
    a process can run before being sent SIGTERM.
 
 `match` blocks are evaluated in order from top to bottom with each successful
@@ -95,20 +95,20 @@ before any user `match` blocks:
 
 ```
 match ".*" {
-  queue = sequential
-  timeout = 3600
+  queue = sequential;
+  timeout = 3600;
 }
 ```
 
 The minimal recommended configuration file is thus:
 
 ```
-listen = "<address>:<port>"
+listen = "<address>:<port>";
 
 github {
-  reposdir = "<path>"
+  reposdir = "<path>";
   match ".*" {
-    email = "<email>"
+    email = "<email>";
   }
 }
 ```
@@ -118,16 +118,16 @@ which are only overridden for specific repositories. For example, for the
 following configuration file:
 
 ```
-port = <port>
+listen = "<address>:<port>";
 
 github {
-  reposdir = "<path>"
+  reposdir = "<path>";
   match ".*" {
-    email = "abc@def.com"
-    secret = "sec"
+    email = "abc@def.com";
+    secret = "sec";
   }
   match "a/b" {
-    email = "ghi@jkl.com"
+    email = "ghi@jkl.com";
   }
 }
 ```

--- a/src/config.l
+++ b/src/config.l
@@ -4,6 +4,7 @@
 = "="
 \{ "{"
 \} "}"
+; ";"
 email "EMAIL"
 evict "EVICT"
 github "GITHUB"

--- a/src/config.y
+++ b/src/config.y
@@ -13,9 +13,9 @@ TopLevelOption -> Result<TopLevelOption<StorageT>, ()>:
         let (options, matches) = $3?;
         Ok(TopLevelOption::GitHub($1.unwrap_or_else(|x| x), options, matches))
     }
-  | "LISTEN" "=" "STRING" { Ok(TopLevelOption::Listen(map_err($3)?)) }
-  | "MAXJOBS" "=" "INT" { Ok(TopLevelOption::MaxJobs(map_err($3)?)) }
-  | "USER" "=" "STRING" { Ok(TopLevelOption::User(map_err($3)?)) }
+  | "LISTEN" "=" "STRING" ";" { Ok(TopLevelOption::Listen(map_err($3)?)) }
+  | "MAXJOBS" "=" "INT" ";" { Ok(TopLevelOption::MaxJobs(map_err($3)?)) }
+  | "USER" "=" "STRING" ";" { Ok(TopLevelOption::User(map_err($3)?)) }
   ;
 
 OptionsOrMatches -> Result<(Vec<ProviderOption<StorageT>>, Vec<Match<StorageT>>), ()>:
@@ -33,7 +33,7 @@ OptionsOrMatches -> Result<(Vec<ProviderOption<StorageT>>, Vec<Match<StorageT>>)
   ;
 
 ProviderOption -> Result<ProviderOption<StorageT>, ()>:
-    "REPOSDIR" "=" "STRING" { Ok(ProviderOption::ReposDir(map_err($3)?)) }
+    "REPOSDIR" "=" "STRING" ";" { Ok(ProviderOption::ReposDir(map_err($3)?)) }
   ;
 
 Matches -> Result<Vec<Match<StorageT>>, ()>:
@@ -51,13 +51,13 @@ PerRepoOptions -> Result<Vec<PerRepoOption<StorageT>>, ()>:
   ;
 
 PerRepoOption -> Result<PerRepoOption<StorageT>, ()>:
-    "EMAIL" "=" "STRING" { Ok(PerRepoOption::Email(map_err($3)?)) }
-  | "QUEUE" "=" QueueKind {
+    "EMAIL" "=" "STRING" ";" { Ok(PerRepoOption::Email(map_err($3)?)) }
+  | "QUEUE" "=" QueueKind ";" {
         let (lexeme, qkind) = $3?;
         Ok(PerRepoOption::Queue(lexeme, qkind))
     }
-  | "SECRET" "=" "STRING" { Ok(PerRepoOption::Secret(map_err($3)?)) }
-  | "TIMEOUT" "=" "INT" { Ok(PerRepoOption::Timeout(map_err($3)?)) }
+  | "SECRET" "=" "STRING" ";" { Ok(PerRepoOption::Secret(map_err($3)?)) }
+  | "TIMEOUT" "=" "INT" ";" { Ok(PerRepoOption::Timeout(map_err($3)?)) }
   ;
 
 QueueKind -> Result<(Lexeme<StorageT>, QueueKind), ()>:


### PR DESCRIPTION
Although this is pure syntactic overhead for now, it will allow us one easy way of of unsetting options (e.g. `email=;`) should we ever want that in the future.