### PR TITLE
Respond to GitHub pings.

### DIFF
--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -66,6 +66,11 @@ async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>,
         return Ok(res);
     }
 
+    if event_type == "ping" {
+        *res.status_mut() = StatusCode::OK;
+        return Ok(res);
+    }
+
     // We now check that there is a per-repo program for this repository and that we haven't been
     // tricked into searching for a file outside of the repos dir.
     let mut p = PathBuf::new();


### PR DESCRIPTION
When a user installs a webhook, GitHub pings the webhook server. This simple commit responds with "success" if, and only if, authentication succeeds *and* there is a script for the repository in question.

@vext01 There is an interesting question here. Should we return success after authentication, even if there's not a script to run? To my mind, that equates to "things aren't fully set up yet, so best to make it clear", but I could be convinced otherwise.