### PR TITLE
Fail authentication if a secret is present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ A `match` block supports the following options:
        jobs will stay on the queue and be executed in FIFO order.
  * `secret = "<secret>";` is an optional GitHub secret which guarantees that
    hooks are coming from your GitHub repository and not a malfeasant. Although
-   this is optional, we *highly* recommend setting it in all cases.
+   this is optional, we *highly* recommend setting it in all cases. Note also
+   that if a GitHub request is signed, but you have not specified a secret,
+   then snare will return the request as "unauthorised" to remind you to use
+   the secret at both ends.
  * `timeout = <timeout>;` optionally specifies the elapsed time in seconds that
    a process can run before being sent SIGTERM.
 


### PR DESCRIPTION
Previously we authenticated successfully if a signature was present, but if the GitHub side shared a secret, and our side didn't, we let it through anyway. In one sense this is fine, but it means that one can easily forget to specify a secret (and when I say "one", I mean "I have already made this mistake").

This commit thus returns `UNAUTHORIZED` if: the request is signed and we don't have a secret; we have a secret and the request isn't signed; or our secret doesn't match the signed request.