### PR TITLE
Audit all the unwrap() calls.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -142,23 +142,17 @@ impl Config {
             }
             _ => process::exit(1),
         }
-        if maxjobs.is_none() {
-            maxjobs = Some(num_cpus::get());
-        }
-        if listen.is_none() {
-            return Err("A 'listen' address must be specified".to_owned());
-        }
-        if github.is_none() {
-            return Err(
-                "A GitHub block with at least a 'repodirs' option must be specified".to_owned(),
-            );
-        }
+        let maxjobs = maxjobs.unwrap_or_else(|| num_cpus::get());
+        let listen = listen.ok_or_else(|| "A 'listen' address must be specified".to_owned())?;
+        let github = github.ok_or_else(|| {
+            "A GitHub block with at least a 'repodirs' option must be specified".to_owned()
+        })?;
 
         Ok(Config {
-            listen: listen.unwrap(),
-            maxjobs: maxjobs.unwrap(),
-            github: github.unwrap(),
-            user: user,
+            listen,
+            maxjobs,
+            github,
+            user,
         })
     }
 }
@@ -343,7 +337,8 @@ impl GitHub {
                 }
             }
         }
-        // Since we know that Matches::default() provides a default timeout, this unwrap() is safe.
+        // Since we know that Matches::default() provides a default queuekind and timeout, both
+        // unwraps() are safe.
         (
             RepoConfig {
                 email,
@@ -370,6 +365,7 @@ pub struct Match {
 
 impl Default for Match {
     fn default() -> Self {
+        // We know that this Regex is valid so the unwrap() is safe.
         let re = Regex::new(".*").unwrap();
         Match {
             re,

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -60,7 +60,6 @@ async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>,
         }
     };
 
-    // If the unwrap() on the lock fails, the other thread has paniced.
     let conf = snare.conf.lock().unwrap();
     let (rconf, secret) = conf.github.repoconfig(&owner, &repo);
 
@@ -102,9 +101,6 @@ async fn handle(req: Request<Body>, snare: Arc<Snare>) -> Result<Response<Body>,
     if let Ok(p) = p.canonicalize() {
         if let Some(s) = p.to_str() {
             if s.starts_with(&conf.github.reposdir) {
-                // We can tolerate the `unwrap` call below because if it fails it means that
-                // something has gone so seriously wrong in the other thread that there's no
-                // likelihood that we can recover.
                 let qj = QueueJob::new(s.to_owned(), req_time, event_type, json_str, rconf);
                 (*snare.queue.lock().unwrap()).push_back(qj);
                 *res.status_mut() = StatusCode::OK;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -105,6 +105,8 @@ impl Queue {
             }
         }
         if let Some(k) = earliest_key {
+            // We know that there's an `Entry` for the key, and that the corresponding value vec
+            // has at least one value, so both unwrap()s are safe.
             Some(self.q.get_mut(&k).unwrap().pop_front().unwrap())
         } else {
             None


### PR DESCRIPTION
In each case do one of the following:

  * Ensure they are documented (and document if not) to explain why they're     safe.
  * If they're not safe, make them safe (e.g. add a fallback, log an error).

The aim here is that snare should not fail at runtime due to `unwrap()` calls.