### PR TITLE
Support for cargo-deny

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,3 +12,6 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 
 cargo fmt --all -- --check
 cargo build
+
+which cargo-deny | cargo install cargo-deny
+cargo-deny check license

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "snare"
 version = "0.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
+license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [build-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+[licenses]
+unlicensed = "deny"
+confidence-threshold = 1.0
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unlicense"
+]
+
+# We'd prefer not to use the MPL if possible, so explicitly whitelist it each
+# time we have to use it.
+exceptions = [
+    { name = "ascii_utils", allow = ["MPL-2.0"] },
+    { name = "fast_chemail", allow = ["MPL-2.0"] }
+]


### PR DESCRIPTION
This PR adds support for [cargo-deny](https://embarkstudios.github.io/cargo-deny/index.html), which makes it harder for us (or a dependency) to accidentally undermine the license we have chosen.