### PR TITLE
Add install instructions and a basic Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+PREFIX ?= /usr/local
+MAN_PREFIX ?= ${PREFIX}/man
+
+all:
+	cargo build --release
+
+install:
+	cargo build --release
+	install -d ${PREFIX}/bin
+	install -c -m 555 target/release/snare ${PREFIX}/bin/snare
+	install -d ${MAN_PREFIX}/man/man1
+	install -d ${MAN_PREFIX}/man/man5
+	install -c -m 444 snare.1 ${MAN_PREFIX}/man/man1/snare.1
+	install -c -m 444 snare.conf.5 ${MAN_PREFIX}/man/man5/snare.conf.5
+	install -d ${PREFIX}/share/examples/snare
+	install -c -m 444 snare.conf.example ${PREFIX}/share/examples/snare
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ arbitrary program for that repository informing it of the event -- that program
 can then perform whatever actions it wants.
 
 
+## Install
+
+You will need rustc-1.40.0 or greater installed. You may use `cargo` to build
+snare locally or you may use the `Makefile` to build and install `snare` in
+traditional Unix fashion. `make install` defaults to installing in
+`/usr/local`: you can override this by setting the `PREFIX` variable to another
+path (e.g. `PREFIX=/opt/local make`).
+
+
 ## Quick setup
 
 `snare` has the following command-line format:


### PR DESCRIPTION
In one sense the Makefile is unnecessary, but it means that normal Unix people who aren't familiar with Rust simply need to install Rust and then type "make install" in order for something sensible to happen. That feels like a reasonable compromise between old and new to me.