### PR TITLE
Replace GitHub-level 'reposdir' with match-level 'cmd'.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,38 @@
+# snare 0.2.0 (xxxx-xx-xx)
+
+## Breaking changes
+
+* The `github`-block level `reposdir` option has been removed. The more
+  flexible `match`-block level `cmd` has been introduced. In essence:
+
+    ```
+    github {
+      reposdir = "/path/to/prps";
+      ...
+    }
+    ```
+
+  should be changed to:
+
+    ```
+    github {
+      match ".*" {
+        cmd = "/path/to/reposdir/%o/%r %e %j";
+      }
+    }
+    ```
+
+  `snare` informs users whose config contains `repodir` how to update it.
+
+
+## Minor changes
+
+* `snare` now validates input derived from the webhook request so that it is
+  safe to pass to the shell: GitHub owners, repositories, and events are all
+  guaranteed to satisfy the regular expression `[a-zA-Z0-9._-]+` and not to be
+  the strings `.` or `..`.
+
+
 # snare 0.1.0 (2020-02-13)
 
 First release.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The minimal recommended configuration file is:
 listen = "<ip-address>:<port>";
 
 github {
-  reposdir = "<path>";
   match ".*" {
+    cmd = "/path/to/prps/%o/%r %e %j";
     email = "<email-address>";
     secret = "<secret>";
   }
@@ -53,19 +53,20 @@ github {
 
 where:
 
-  * `ip-address` is either an IPv4 or IPv6 address and `port` a port on which an
-    HTTP server will listen.
-  * `path` is the directory where the per-repo programs are stored. For a
-    repository `repo` owned by `user` the command:
+ * `ip-address` is either an IPv4 or IPv6 address and `port` a port on which an
+   HTTP server will listen.
+ * `cmd` is the command that will be executed when a webhook is received. In
+   this case, `/path/to/prps` is a path to a directory where per-repo programs
+   are stored. For a repository `repo` owned by `user` the command:
 
-      ```
-      <reposdir>/<user>/<repo> <event> <path to GitHub JSON>
-      ```
+     ```
+     /path/to/prps/<user>/<repo> <event> <path-to-github-json>
+     ```
 
-    will be run. The file `<repo>` must be executable. Note that per-repo
-    programs are run with their current working directory set to a temporary
-    directory to which they can freely write and which will be automatically
-    removed when they have completed.
+   will be run. The file `<repo>` must be executable. Note that commands are
+   run with their current working directory set to a temporary directory to
+   which they can freely write and which will be automatically removed when
+   they have completed.
  * `email-address` is an email address to which any errors running per-repo
    programs will be sent (warning: full stderr/stdout will be sent, so consider
    carefully whether these have sensitive information or not). This uses
@@ -80,14 +81,15 @@ snare.conf](https://softdevteam.github.io/snare/snare.conf.5.html) contains the
 complete list of configuration options.
 
 
-## Per-repo programs
+## Commands
 
-When using snare, the *per-repo programs* do the actual work of executing
-specific actions for a given repository.  For example, `snare`'s GitHub
+`snare` can be used to run any command runnable from the Unix shell. The
+"per-repo program" model as documented above is one common way of doing this.
+For example, `snare`'s GitHub
 repository is
 [`https://github.com/softdevteam/snare`](https://github.com/softdevteam/snare).
 If we set up a web hook up for that repository that notifies us of pull request
-events, then the command:
+events, then with the above `snare.conf`, the command:
 
 ```sh
 <repo-programs-dir>/softdevteam/snare pull_request /path/to/json
@@ -95,7 +97,7 @@ events, then the command:
 
 will be executed, where: `pull_request` is the name of the GitHub event; and
 `/path/to/json` is a path to a file containing the complete GitHub JSON for
-that event. The `softdevteam_snare` program can then execute whatever it wants.
+that event. The `softdevteam/snare` program can then execute whatever it wants.
 In order to work out precisely what event has happened, you will need to read
 [GitHub's webhooks documentation](https://developer.github.com/webhooks/).
 

--- a/snare.conf.5
+++ b/snare.conf.5
@@ -62,8 +62,7 @@ sets the $USER environment variable to
 .Em user-name .
 .El
 .Pp
-All other environment variables are passed through to per-repo programs
-unchanged.
+All other environment variables are passed through to commands unchanged.
 .It Sy github { ... }
 specifies GitHub specific options.
 .El
@@ -72,10 +71,6 @@ A
 .Sq github
 block supports the following options:
 .Bl -tag -width Ds
-.It Sy reposdir = Qq Em path ;
-is a path to a directory containing per-repo programs (see
-.Sx PER-REPO PROGRAMS
-for more information).
 .It Sy match Qo Em regex Qc { Em match-options }
 where
 .Em regex
@@ -105,11 +100,42 @@ A
 .Sq match
 block supports the following options:
 .Bl -tag -width Ds
+.It Sy cmd = Qq Em shell-cmd ;
+optionally specifies a command to be run.
+.Em shell-cmd
+will be executed via
+.Ql $SHELL -c .
+The following escape sequences are recognised and replaced before execution:
+.Bl -tag -width Ds
+.It Sy %e
+the GitHub event type (e.g.
+.Ql pull_request ) .
+.It Sy %j
+the path to the GitHub JSON.
+.It Sy %o
+the repository owner.
+.It Sy %r
+the repository.
+.It Sy %%
+a literal
+.Ql % .
+.El
+Note that
+.Ql %
+may not be followed by any character other than those above.
+.Pp
+The escape sequences are guaranteed to satisfy the regular expression
+.Qq [a-zA-Z0-9._-]+
+and not to be the strings
+.Qq \&.
+or
+.Qq .. .
+This means that they are safe to pass as shell arguments and/or to be included
+in file system paths.
 .It Sy email = Qq Em address ;
-optionally specifies an email address to which any
-errors running per-repo programs will be sent (warning: full stderr/stdout
-will be sent, so consider carefully whether these have sensitive information
-or not).
+optionally specifies an email address to which any errors when running commands
+will be sent (warning: full stderr/stdout will be sent, so consider carefully
+whether these have sensitive information or not).
 This uses the `sendmail` command to send email: you should ensure that you have
 installed, set-up, and enabled a suitable `sendmail` clone.
 .It Sy queue = Po evict | parallel | sequential Pc ;
@@ -170,49 +196,6 @@ match ".*" {
   timeout = 3600;
 }
 .Ed
-.Sh PER-REPO PROGRAMS
-When using
-.Nm ,
-the per-repo programs do the actual work of executing specific actions for a
-given repository.
-For a repository repo owned by
-.Ql user ,
-the command
-.Bd -literal -offset 4n
-<reposdir>/<user>/<repo> <event> <path-to-GitHub-JSON>
-.Ed
-.Pp
-will be run.
-Per-repo programs must be marked as executable and are run with their current
-working directory set to a temporary directory to which they can freely write
-and which will be automatically removed when they have completed.
-.Pp
-For example, snare's GitHub repository is
-.Lk https://github.com/softdevteam/snare .
-If we set up a web hook up for that repository that notifies us of pull request
-events, then the command:
-.Bd -literal -offset 4n
-/path/to/softdevteam/snare pull_request /path/to/json
-.Ed
-.Pp
-will be executed, where:
-.Bl -tag -width Ds
-.It Sy /path/to/softdevteam/snare
-is the per-repo program for the
-.Dq softdevteam
-user and the
-.Dq snare
-repository.
-.It Sy pull_request
-is the type of the GitHub event.
-.It Sy /path/to/json
-is a path to a file containing the complete GitHub JSON for that
-event.
-.El
-.Pp
-The softdevteam/snare per-repo program can then execute whatever it wants.
-In order to work out precisely what event has happened, you will need to read
-.Lk https://developer.github.com/webhooks/ GitHub's webhooks documentation .
 .Sh EXAMPLES
 The minimal recommended
 .Nm
@@ -220,13 +203,21 @@ file is as follows:
 .Bd -literal -offset 4n
 listen = "<address>:<port>";
 github {
-  reposdir = "<path>";
   match ".*" {
+    cmd = "/path/to/prps/%o/%r %e %j";
     email = "<email>";
     secret = "<secret>";
   }
 }
 .Ed
+.Pp
+where
+.Qq /path/to/prps
+is a path to a directory where per-repo programs are stored.
+Each repository then has a unique program
+.Qq %o/%r
+which will be executed with two arguments: the GitHub event; and the path to
+the GitHub JSON.
 .Pp
 The top-to-bottom evaluation of match blocks allow users to specify defaults
 which are only overridden for specific repositories.
@@ -236,6 +227,7 @@ listen = "<address>:<port>";
 github {
   reposdir = "<path>";
   match ".*" {
+    cmd = "/path/to/prps/%o/%r %e %j";
     email = "abc@def.com";
     secret = "sec";
   }
@@ -250,19 +242,21 @@ the following repositories will have these settings:
 a/b:
   queue = sequential
   timeout = 3600
+  cmd = "/path/to/prps/%o/%r %e %j";
   email = "ghi@jkl.com"
   secret = "sec"
 c/d:
   queue = sequential
   timeout = 3600
+  cmd = "/path/to/prps/%o/%r %e %j";
   email = "abc@def.com"
   secret = "sec"
 .Ed
 .Pp
-Users can write per-repo programs in whatever system/language they wish, so
-long as the matching file is marked as executable.
-The following simple example uses shell script to send a list of commits and
-diffs to the address specified in $EMAIL on each
+The following program expects to be called with an event and a JSON path (i.e.
+.Qq %e %j )
+and uses shell script to send a list of commits and diffs to the address
+specified in $EMAIL on each
 .Dq push
 event.
 It works for any public GitHub repository:
@@ -295,14 +289,16 @@ complex and powerful (for example, not cloning afresh on each pull).
 .Pp
 Note that this program is deliberately untrusting of external input: it is
 careful to quote all arguments obtained from JSON; and it uses a fixed
-directory name (
-.Dq repo )
+directory name
+.Pf ( Dq repo )
 rather than a file name from JSON that might
 include characters (such as
 .Dq ../.. )
 that would cause the script to leak data about other parts of the file system.
 .Sh SEE ALSO
 .Xr snare 1
+.Pp
+.Lk https://developer.github.com/webhooks/ GitHub's webhooks documentation .
 .Sh AUTHORS
 .An -nosplit
 .Xr snare 1

--- a/src/config.l
+++ b/src/config.l
@@ -5,6 +5,7 @@
 \{ "{"
 \} "}"
 ; ";"
+cmd "CMD"
 email "EMAIL"
 evict "EVICT"
 github "GITHUB"

--- a/src/config.y
+++ b/src/config.y
@@ -51,7 +51,8 @@ PerRepoOptions -> Result<Vec<PerRepoOption>, ()>:
   ;
 
 PerRepoOption -> Result<PerRepoOption, ()>:
-    "EMAIL" "=" "STRING" ";" { Ok(PerRepoOption::Email(map_err($3)?)) }
+    "CMD" "=" "STRING" ";" { Ok(PerRepoOption::Cmd(map_err($3)?)) }
+  | "EMAIL" "=" "STRING" ";" { Ok(PerRepoOption::Email(map_err($3)?)) }
   | "QUEUE" "=" QueueKind ";" {
         let (span, qkind) = $3?;
         Ok(PerRepoOption::Queue(span, qkind))

--- a/src/config_ast.rs
+++ b/src/config_ast.rs
@@ -17,6 +17,7 @@ pub struct Match {
 }
 
 pub enum PerRepoOption {
+    Cmd(Span),
     Email(Span),
     Queue(Span, QueueKind),
     Secret(Span),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-//! snare is a GitHub webhooks runner. Architecturally it is split in two:
+//! snare is a GitHub webhooks daemon. Architecturally it is split in two:
 //!   * The `httpserver` listens for incoming hooks, checks that they're valid, and adds them to a
 //!     `Queue`.
 //!   * The `jobrunner` pops elements from the `Queue` and runs them in parallel.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -6,7 +6,9 @@ use std::{
 use crate::config::{QueueKind, RepoConfig};
 
 pub(crate) struct QueueJob {
-    pub path: String,
+    pub repo_id: String,
+    pub owner: String,
+    pub repo: String,
     pub req_time: Instant,
     pub event_type: String,
     pub json_str: String,
@@ -15,14 +17,18 @@ pub(crate) struct QueueJob {
 
 impl QueueJob {
     pub fn new(
-        path: String,
+        repo_id: String,
+        owner: String,
+        repo: String,
         req_time: Instant,
         event_type: String,
         json_str: String,
         rconf: RepoConfig,
     ) -> Self {
         QueueJob {
-            path,
+            repo_id,
+            owner,
+            repo,
             req_time,
             event_type,
             json_str,
@@ -50,9 +56,9 @@ impl Queue {
         true
     }
 
-    /// For the per-repo program at `path`, push a new request.
+    /// Push a new request to the back of the queue.
     pub fn push_back(&mut self, qj: QueueJob) {
-        let mut entry = self.q.entry(qj.path.clone());
+        let mut entry = self.q.entry(qj.repo_id.clone());
 
         match qj.rconf.queuekind {
             QueueKind::Evict => {
@@ -63,21 +69,21 @@ impl Queue {
         entry.or_insert_with(VecDeque::new).push_back(qj);
     }
 
-    /// For the per-repo program at `path`, push an old request that has had to be requeued due to
-    /// a (hopefully) temporary error. In order that jobs are not unnecessarily pushed on the queue
-    /// (which could happen with the `Evict` queue kind), the lock on `self` should be held between
-    /// calls to `pop` and `push_front`.
+    /// Push an old request which has failed due to a temporary error back to the front of the
+    /// queue so that it can be retried again on the next poll. In order that jobs are not
+    /// unnecessarily pushed on the queue (which could happen with the `Evict` queue kind), the
+    /// lock on `self` should be held between calls to `pop` and `push_front`.
     pub fn push_front(&mut self, qj: QueueJob) {
         self.q
-            .entry(qj.path.clone())
+            .entry(qj.repo_id.clone())
             .or_insert_with(VecDeque::new)
             .push_front(qj);
     }
 
     /// If the queue has a runnable entry, pop and return it, or `None` otherwise. Note that `None`
     /// does not guarantee that the queue is empty: it may mean that there are queued jobs that
-    /// can't be run until existing jobs finish. `running(path)` is a function which must return
-    /// `true` if a job at `path` is currently running and `false` otherwise.
+    /// can't be run until existing jobs finish. `running(repo_id)` is a function which must return
+    /// `true` if a job at `repo_id` is currently running and `false` otherwise.
     pub fn pop<F>(&mut self, running: F) -> Option<QueueJob>
     where
         F: Fn(&str) -> bool,
@@ -95,7 +101,7 @@ impl Queue {
                 match qj.rconf.queuekind {
                     QueueKind::Parallel => (),
                     QueueKind::Evict | QueueKind::Sequential => {
-                        if running(&qj.path) {
+                        if running(&qj.repo_id) {
                             continue;
                         }
                     }


### PR DESCRIPTION
This commit removes the `github`-block level `reposdir` and replaces it with the more flexible `match`-block level `cmd` has been introduced. In essence:

```
  github {
    reposdir = "/path/to/prps";
    ...
  }
```

should be changed to:

```
  github {
    match ".*" {
      cmd = "/path/to/reposdir/%o/%r %e %j";
    }
  }
```

in order to obtain the previous behaviour. `snare` informs users whose config contains `repodir` how to update it, hopefully minimising porting from snare-0.1.0.