### PR TITLE
String escapes

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -11,7 +11,7 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain stable 
 export PATH=`pwd`/.cargo/bin/:$PATH
 
 cargo fmt --all -- --check
-cargo build
+cargo test
 
 mkdir test_install
 PREFIX=test_install make install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
   guaranteed to satisfy the regular expression `[a-zA-Z0-9._-]+` and not to be
   the strings `.` or `..`.
 
+* String escapes (e.g. "\"") are now properly processed (previously they were
+  ignored).
+
 
 # snare 0.1.0 (2020-02-13)
 


### PR DESCRIPTION
Process escaped strings in the config file.
    
The regex in config.l supported strings such as:

```    
cmd = "\"\\";
```

but we didn't actually process the `\` characters, which was something of an oversight!
