### PR TITLE
Turn lexing errors into parsing errors.

### DIFF
--- a/src/config.l
+++ b/src/config.l
@@ -20,4 +20,5 @@ sequential "SEQUENTIAL"
 timeout "TIMEOUT"
 user "USER"
 //.*?$ ;
-[ \t\n\r]* ;
+[ \t\n\r]+ ;
+. "UNKNOWN"

--- a/src/config.y
+++ b/src/config.y
@@ -67,6 +67,11 @@ QueueKind -> Result<(Span, QueueKind), ()>:
   | "SEQUENTIAL" { Ok((map_err($1)?, QueueKind::Sequential)) }
   ;
 
+// This rule helps turn lexing errors into parsing errors.
+Unknown -> ():
+    "UNKNOWN" { }
+  ;
+
 %%
 use lrpar::{Lexeme, Span};
 


### PR DESCRIPTION
Consider this (incorrect) snippet of a snare.conf:

```
  listen = "0.0.0.0:8011";
  maxjob = 4;
```

Before this commit you would simply be told:

```
  Lexing error at line 2 column 1.
```

which is accurate, but not very helpful. This commit adds a simple rule which, if no other lexing rules apply, consumes one character of the input into an "UNKNOWN" token. Thus every possible input can now be lexed, and lexing errors are now replaced by parsing errors, which means that error recovery can now kick in. Thus the above snippet now leads to:

```
  Parsing error at line 2 column 1. Repair sequences found:
     1: Insert MAXJOBS, Delete m, Delete a, Delete x, Delete j, Delete o, Delete b.
```