### PR TITLE
Always chdir to '/'.

### DIFF
--- a/snare.conf.5
+++ b/snare.conf.5
@@ -52,9 +52,6 @@ changes its uid, euid, suid to the UID of
 changes its gid, egid, sgid to the primary GID of
 .Em user-name .
 .It
-changes its CWD to the home directory of
-.Em user-name .
-.It
 sets the $HOME environment variable to the home directory of
 .Em user-name .
 .It


### PR DESCRIPTION
Previously we left snare with its CWD unchanged unless a `user` was specified at
which point we (for no obvious reason) changed CWD to `user`'s `$HOME`. This
small difference seems pointless: by always setting CWD to `/` we lessen the
chance of users relying on the CWD.