### PR TITLE
errorcmd

### DIFF
--- a/snare.conf.5
+++ b/snare.conf.5
@@ -230,7 +230,7 @@ listen = "<address>:<port>";
 github {
   match ".*" {
     cmd = "/path/to/prps/%o/%r %e %j";
-    error_cmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" someone@example.com";
+    errorcmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" someone@example.com";
     secret = "<secret>";
   }
 }
@@ -256,11 +256,11 @@ github {
   reposdir = "<path>";
   match ".*" {
     cmd = "/path/to/prps/%o/%r %e %j";
-    error_cmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" abc@def.com";
+    errorcmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" abc@def.com";
     secret = "sec";
   }
   match "a/b" {
-    error_cmd = "lpr %s";
+    errorcmd = "lpr %s";
   }
 }
 .Ed
@@ -271,13 +271,13 @@ a/b:
   queue = sequential
   timeout = 3600
   cmd = "/path/to/prps/%o/%r %e %j";
-  error_cmd = "lpr %s";
+  errorcmd = "lpr %s";
   secret = "sec"
 c/d:
   queue = sequential
   timeout = 3600
   cmd = "/path/to/prps/%o/%r %e %j";
-  error_cmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" abc@def.com";
+  errorcmd = "cat %s | mailx -s \\"snare error: github.com/%o/%r\\" abc@def.com";
   secret = "sec"
 .Ed
 .Pp

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,14 +197,14 @@ impl GitHub {
                         cmd = Some(cmd_str);
                     }
                     config_ast::PerRepoOption::Email(span) => {
-                        return Err(error_at_span(lexer, span, "Replace:\n  email = \"someone@example.com\"; }\nwith:\n  error_cmd = \"cat %f | mailx -s \\\"snare error: github.com/%o/%r\\\" someone@example.com\";"));
+                        return Err(error_at_span(lexer, span, "Replace:\n  email = \"someone@example.com\"; }\nwith:\n  errorcmd = \"cat %f | mailx -s \\\"snare error: github.com/%o/%r\\\" someone@example.com\";"));
                     }
                     config_ast::PerRepoOption::ErrorCmd(span) => {
                         if errorcmd.is_some() {
                             return Err(error_at_span(
                                 lexer,
                                 span,
-                                "Mustn't specify 'error_cmd' more than once",
+                                "Mustn't specify 'errorcmd' more than once",
                             ));
                         }
                         let errorcmd_str = unescape_str(lexer.span_str(span));

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,7 +197,7 @@ impl GitHub {
                         cmd = Some(cmd_str);
                     }
                     config_ast::PerRepoOption::Email(span) => {
-                        return Err(error_at_span(lexer, span, "Replace:\n  email = \"someone@example.com\"; }\nwith:\n  errorcmd = \"cat %f | mailx -s \\\"snare error: github.com/%o/%r\\\" someone@example.com\";"));
+                        return Err(error_at_span(lexer, span, "Replace:\n  email = \"someone@example.com\"; }\nwith:\n  errorcmd = \"cat %s | mailx -s \\\"snare error: github.com/%o/%r\\\" someone@example.com\";"));
                     }
                     config_ast::PerRepoOption::ErrorCmd(span) => {
                         if errorcmd.is_some() {


### PR DESCRIPTION
This PR fixes a couple of typo-ish flaws where the `errorcmd` documentation (and related) bits misspelt things.