### PR TITLE
Prepare a 0.4.1 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# snare 0.4.1 (2020-12-03)
+
+* Documentation improvements, including more secure examples.
+
+* Updated dependencies, solving a long-standing slow error leak.
+
+
 # snare 0.4.0 (2020-05-13)
 
 ## Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snare"
 description = "GitHub webhooks runner daemon"
-version = "0.4.0"
+version = "0.4.1"
 homepage = "https://tratt.net/laurie/src/snare/"
 repository = "https://github.com/softdevteam/snare/"
 authors = ["Laurence Tratt <laurie@tratt.net>"]


### PR DESCRIPTION
The main reason for this release is to solve a slow memory leak in snare: each request would consume something around 24-32 bytes for no reason. I spent a while debugging this a couple of months ago, only to conclude that it didn't appear to be in the snare code itself but in a dependency (thought the waters were muddied by the fact that several dependencies allocated memory at various points, so it wasn't clear which might be the culprit).

Having now updated all the dependencies, I've run some stress tests (including firing a few tens of thousands of requests at snare), and the leak now appears to be gone. The first few requests cause snare's memory allocation to gradually increase but it soon stabilises (assuming, of course, that the queue doesn't grow: that's a perfectly good reason for memory usage to increase!).