### PR TITLE
Prepare a 0.4.8 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# snare 0.4.8 (2023-03-08)
+
+* Update dependencies.
+
+
 # snare 0.4.7 (2023-02-06)
 
 * Update dependencies, including moving from the unmaintained `json` crate to `serde_json`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snare"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "cfgrammar",
  "crypto-common",
@@ -1268,7 +1268,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[patch.unused]]
-name = "ring"
-version = "0.16.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snare"
 description = "GitHub webhooks runner daemon"
-version = "0.4.7"
+version = "0.4.8"
 homepage = "https://tratt.net/laurie/src/snare/"
 repository = "https://github.com/softdevteam/snare/"
 authors = ["Laurence Tratt <laurie@tratt.net>"]


### PR DESCRIPTION
Note that this removes the (incorrect) `ring` part of `Cargo.lock` which I accidentally left in due to a temporary hack for `ring` on OpenBSD.