### PR TITLE
Remove hyper & tokio; implement an HTTP server; and add system tests.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,6 +12,7 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 
 cargo fmt --all -- --check
 cargo test
+cargo test --release
 
 mkdir test_install
 PREFIX=test_install make install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,31 +12,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bincode"
@@ -90,29 +81,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
-
-[[package]]
-name = "bytes"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cactus"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf034765b7d19a011c6d619e880582bf95e8186b580e6fab56589872dd87dcf5"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -206,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +198,18 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"
@@ -257,39 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
-
-[[package]]
-name = "futures-task"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
-
-[[package]]
-name = "futures-util"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,12 +269,6 @@ checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "globset"
@@ -355,63 +311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,16 +368,6 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -556,26 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,21 +495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
 name = "packedvec"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,39 +505,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -687,6 +521,34 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "predicates"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -768,12 +630,6 @@ checksum = "89974a5bef01d82b843f85cbab168e8554b3776f875dcc7a66bf03c757db5ab1"
 dependencies = [
  "ignore",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -871,10 +727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha2"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -901,22 +757,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
 name = "snare"
 version = "0.4.8"
 dependencies = [
+ "assert_cmd",
  "cfgrammar",
  "crypto-common",
  "crypto-mac",
  "getopts",
  "hex",
  "hmac",
- "hyper",
  "libc",
  "lrlex",
  "lrpar",
@@ -928,30 +778,10 @@ dependencies = [
  "rerun_except",
  "secstr",
  "serde_json",
- "sha-1",
+ "sha2",
  "signal-hook",
  "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1001,6 +831,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
@@ -1054,67 +890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.5.5",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,21 +953,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ crypto-mac = "0.11"
 getopts = "0.2"
 hex = "0.4"
 hmac = "0.12"
-hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
 libc = "0.2"
 lrlex = "0.13"
 lrpar = "0.13"
@@ -35,10 +34,13 @@ pwd = "1"
 regex = "1.7"
 secstr = "0.5"
 serde_json = "1"
-sha-1 = "0.10"
+sha2 = "0.10"
 signal-hook = "0.3"
 tempfile = "3"
-tokio = { version = "1.24", features = ["full"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+wait-timeout = "0.2"
 
 [profile.release]
 opt-level = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use lrlex::{lrlex_mod, DefaultLexerTypes, LRNonStreamingLexer};
 use lrpar::{lrpar_mod, NonStreamingLexer, Span};
 use regex::Regex;
 use secstr::SecStr;
-use sha1::Sha1;
+use sha2::Sha256;
 
 use crate::config_ast;
 
@@ -239,7 +239,7 @@ impl GitHub {
                         // invalid length despite the API suggesting that it can be... We're
                         // conservative and assume that it really is possible to have an invalid
                         // length key.
-                        match Hmac::<Sha1>::new_from_slice(sec_str.as_bytes()) {
+                        match Hmac::<Sha256>::new_from_slice(sec_str.as_bytes()) {
                             Ok(_) => (),
                             Err(InvalidLength) => {
                                 return Err(error_at_span(lexer, span, "Invalid secret key length"))

--- a/src/jobrunner.rs
+++ b/src/jobrunner.rs
@@ -58,7 +58,7 @@ struct JobRunner {
 
 impl JobRunner {
     fn new(snare: Arc<Snare>) -> Result<Self, Box<dyn Error>> {
-        let shell = env::var("SHELL")?;
+        let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_owned());
         let maxjobs = snare.conf.lock().unwrap().maxjobs;
         assert!(maxjobs <= (std::usize::MAX - 1) / 2);
         let mut running = Vec::with_capacity(maxjobs);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,179 @@
+use assert_cmd::prelude::*;
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+use std::{
+    convert::{TryFrom, TryInto},
+    error::Error,
+    io::{Read, Write},
+    net::{Shutdown, TcpStream},
+    os::unix::process::ExitStatusExt,
+    panic::{catch_unwind, resume_unwind, UnwindSafe},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread::sleep,
+    time::Duration,
+};
+use tempfile::Builder;
+use wait_timeout::ChildExt;
+
+/// At various points we want to wait for the snare process we've started to do something (e.g.
+/// initialise itself): but we have no way of knowing if it's done it or not. The best we can do is
+/// to wait for a little bit, hope it does what we want, and then continue with our test. This
+/// constant defines how long we wait at any given point. There is no perfect value here: one can
+/// always have a box which (perhaps because it's loaded) causes arbitrarily long pauses. So we set
+/// a fairly high threshold, hoping that will deal with most reasonable cases, and then cross our
+/// fingers!
+static SNARE_PAUSE: Duration = Duration::from_secs(1);
+/// When we send SIGTERM to a snare instance, what is the maximum time we should wait for the
+/// process to exit? We don't expect this maximum time to be reached often, so a fairly high
+/// threshold is tolerable, and doing so maximises the chance that we get something useful printed
+/// to stdout/stderr.
+static SNARE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn run<F, G>(cfg: &str, while_running: F, check_exit: G) -> Result<(), Box<dyn Error>>
+where
+    F: FnOnce(&Child) -> Result<(), Box<dyn Error>> + UnwindSafe + 'static,
+    G: FnOnce(ExitStatus) -> Result<(), Box<dyn Error>> + 'static,
+{
+    let mut tc = Builder::new().tempfile_in(env!("CARGO_TARGET_TMPDIR"))?;
+    write!(tc, "{cfg}")?;
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.args(["-d", "-c", tc.path().to_str().unwrap()]);
+    let mut sn = cmd.spawn()?;
+    // We want to wait for snare to fully initialise: there is no way of doing that other than
+    // waiting and hoping.
+    sleep(SNARE_PAUSE);
+    // Try as hard as possible not to leave snare processes lurking around after the tests are run,
+    // by sending them SIGTERM in as many cases as we reasonably can. Note that `catch_unwind` does
+    // not guarantee to catch all panic-y situations, so this can never be perfect.
+    let r = catch_unwind(|| while_running(&sn));
+    kill(Pid::from_raw(sn.id().try_into()?), Signal::SIGTERM)?;
+    if let Err(_) | Ok(Err(_)) = r {
+        let ec = match sn.wait_timeout(SNARE_WAIT_TIMEOUT) {
+            Err(e) => e.to_string(),
+            Ok(None) => "stalled without exiting".to_owned(),
+            Ok(Some(ec)) => ec
+                .code()
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "<no exit code>".to_owned()),
+        };
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        sn.stdout.as_mut().unwrap().read_to_string(&mut stdout).ok();
+        if stdout.len() > 0 {
+            stdout.push('\n');
+        }
+        sn.stderr.as_mut().unwrap().read_to_string(&mut stderr).ok();
+        eprintln!(
+            "snare child process:\n  Exit status: {ec}\n\n  stdout:\n{stdout}\n  stderr:\n{stderr}"
+        );
+    }
+    match r {
+        Err(r) => resume_unwind(r),
+        Ok(Ok(_)) => (),
+        Ok(Err(e)) => return Err(e),
+    }
+
+    match sn.wait_timeout(SNARE_WAIT_TIMEOUT) {
+        Err(e) => Err(e.into()),
+        Ok(Some(ec)) => check_exit(ec),
+        Ok(None) => Err("timeout waiting for snare to exit".into()),
+    }
+}
+
+fn exit_success(es: ExitStatus) -> Result<(), Box<dyn Error>> {
+    if let Some(Signal::SIGTERM) = es.signal().map(|x| Signal::try_from(x).unwrap()) {
+        Ok(())
+    } else {
+        Err(format!("Expected successful exit but got '{es:?}'").into())
+    }
+}
+
+fn exit_error(es: ExitStatus) -> Result<(), Box<dyn Error>> {
+    if !es.success() {
+        Ok(())
+    } else {
+        Err(format!("Expected unsuccessful exit but got '{es:?}'").into())
+    }
+}
+
+#[test]
+fn minimal_config() -> Result<(), Box<dyn Error>> {
+    run(
+        r#"listen = "127.0.0.1:28083";
+github {
+}"#,
+        |_| Ok(()),
+        exit_success,
+    )
+}
+
+#[test]
+fn bad_config() -> Result<(), Box<dyn Error>> {
+    run(r#""#, |_| Ok(()), exit_error)
+}
+
+#[test]
+fn full_request() -> Result<(), Box<dyn Error>> {
+    // This test checks that snare both responds to, and executes the correct command for, a given
+    // (user, repo) pair. It does that by checking that snare executes `touch <tempfile>`.
+
+    let td = Builder::new().tempdir_in(env!("CARGO_TARGET_TMPDIR"))?;
+    let mut tp = td.path().to_owned();
+    tp.push("t");
+    let tps = tp.as_path().to_str().unwrap();
+    // Example secret and payload from
+    // https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#testing-the-webhook-payload-validation
+    let req = r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:28084
+Content-Length: 104
+X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
+X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
+User-Agent: GitHub-Hookshot/044aadd
+Content-Type: application/json
+X-GitHub-Event: issues
+X-GitHub-Hook-ID: 292430182
+X-GitHub-Hook-Installation-Target-ID: 79929171
+X-GitHub-Hook-Installation-Target-Type: repository
+
+payload={
+  "repository": {
+    "owner": {
+      "login": "testuser"
+    },
+    "name": "testrepo"
+  }
+}"#;
+
+    run(
+        &format!(
+            r#"listen = "127.0.0.1:28084";
+github {{
+  match ".*" {{
+    cmd = "touch {tps}";
+    secret = "secretsecret";
+  }}
+}}"#
+        ),
+        move |_| {
+            assert!(!tp.is_file());
+            let mut stream = TcpStream::connect("127.0.0.1:28084")?;
+            stream.write(req.as_bytes())?;
+            stream.shutdown(Shutdown::Write)?;
+            let mut s = String::new();
+            stream.read_to_string(&mut s)?;
+            if s.starts_with("HTTP/1.1 200 OK") {
+                // We want to wait for snare to fully initialise: there is no way of doing that other than
+                // waiting and hoping.
+                sleep(SNARE_PAUSE);
+                assert!(tp.is_file());
+                Ok(())
+            } else {
+                Err(format!("Received HTTP response '{s}'").into())
+            }
+        },
+        exit_success,
+    )
+}


### PR DESCRIPTION
This commit is a thorough yak shave. First I tried to upgrade hyper, which we previously used for snare's HTTP server. However, it has thoroughly changed its API and no longer provides an HTTP server directly (there is an external crate which is supposed to work, but I couldn't get it to compile). That slowly made me rethink snare's HTTP server, because the use of hyper is why snare also required tokio, with all that comes with it (async, lots of dependencies, and the overloading of my pea brain).

So, second, I removed hyper and tokio and implemented my own minimalistic HTTP server (heavily modelled on pizauth). This hugely reduces our dependencies (from 213 -> 172 for `cargo build`) and reduces the final binary size by 20% in release mode.

However, how do we know that taking on the burden of running our own HTTP server has left snare correct? One of snare's long-term weaknesses is that we haven't have good system-level tests, and I've often been lacking confidence when working on snare that my changes haven't broken something important.

So, third, and finally, this commit adds system level tests is `tests/basic.rs`. The most thorough of these fires a full GitHub-esque request at snare, forcing it to authenticate, and run a test command. While it's not perfect, it's a lot better than nothing.

This commit has also survived being run against GitHub itself. There is more to do (e.g. the tests currently bind to fixed ports; and there aren't enough system tests), but this feels like a sufficiently big unit of work in and of itself.