### PR TITLE
Don't bind to fixed ports in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,31 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
-name = "assert_cmd"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
 
 [[package]]
 name = "autocfg"
@@ -81,7 +60,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde",
 ]
 
@@ -183,12 +161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,18 +170,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"
@@ -225,6 +185,18 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "escargot"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -334,15 +306,6 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -495,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "packedvec"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,34 +490,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "predicates"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
-dependencies = [
- "anstyle",
- "difflib",
- "itertools",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -760,10 +701,10 @@ dependencies = [
 name = "snare"
 version = "0.4.8"
 dependencies = [
- "assert_cmd",
  "cfgrammar",
  "crypto-common",
  "crypto-mac",
+ "escargot",
  "getopts",
  "hex",
  "hmac",
@@ -831,12 +772,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,12 @@ signal-hook = "0.3"
 tempfile = "3"
 
 [dev-dependencies]
-assert_cmd = "2"
+escargot = "0.5"
 wait-timeout = "0.2"
+
+[features]
+default = []
+_internal_testing = []
 
 [profile.release]
 opt-level = 3

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -29,6 +29,13 @@ static MAX_HTTP_BODY_SIZE: usize = 64 * 1024;
 
 pub(crate) fn serve(snare: Arc<Snare>) -> Result<(), Box<dyn Error>> {
     let listener = TcpListener::bind(snare.conf.lock().unwrap().listen)?;
+    #[cfg(feature = "_internal_testing")]
+    {
+        if let Ok(p) = std::env::var("SNARE_DEBUG_PORT_PATH") {
+            std::fs::write(p, &listener.local_addr().unwrap().port().to_string()).unwrap();
+        }
+    }
+
     let active = Arc::new(AtomicUsize::new(0));
     for mut stream in listener.incoming().flatten() {
         // We want to keep a limit on how many threads are started concurrently, so that an

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,3 @@
-use assert_cmd::prelude::*;
 use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid,
@@ -6,11 +5,12 @@ use nix::{
 use std::{
     convert::{TryFrom, TryInto},
     error::Error,
+    fs::read_to_string,
     io::{Read, Write},
     net::{Shutdown, TcpStream},
     os::unix::process::ExitStatusExt,
     panic::{catch_unwind, resume_unwind, UnwindSafe},
-    process::{Child, Command, ExitStatus, Stdio},
+    process::{ExitStatus, Stdio},
     thread::sleep,
     time::Duration,
 };
@@ -31,26 +31,52 @@ static SNARE_PAUSE: Duration = Duration::from_secs(1);
 /// to stdout/stderr.
 static SNARE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
-fn run<F, G>(cfg: &str, while_running: F, check_exit: G) -> Result<(), Box<dyn Error>>
+fn run<F, G, H>(cfg: &str, req: F, check_response: G, check_exit: H) -> Result<(), Box<dyn Error>>
 where
-    F: FnOnce(&Child) -> Result<(), Box<dyn Error>> + UnwindSafe + 'static,
-    G: FnOnce(ExitStatus) -> Result<(), Box<dyn Error>> + 'static,
+    F: FnOnce(u16) -> Result<String, Box<dyn Error>> + UnwindSafe + 'static,
+    G: FnOnce(String) -> Result<(), Box<dyn Error>> + UnwindSafe + 'static,
+    H: FnOnce(ExitStatus) -> Result<(), Box<dyn Error>> + 'static,
 {
     let mut tc = Builder::new().tempfile_in(env!("CARGO_TARGET_TMPDIR"))?;
     write!(tc, "{cfg}")?;
-    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+    let mut cmd = escargot::CargoBuild::new()
+        .bin("snare")
+        .current_release()
+        .current_target()
+        .no_default_features()
+        .features("_internal_testing")
+        .run()?
+        .command();
+    let tp = Builder::new().tempfile_in(env!("CARGO_TARGET_TMPDIR"))?;
+    cmd.env("SNARE_DEBUG_PORT_PATH", tp.path().to_str().unwrap());
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     cmd.args(["-d", "-c", tc.path().to_str().unwrap()]);
     let mut sn = cmd.spawn()?;
     // We want to wait for snare to fully initialise: there is no way of doing that other than
     // waiting and hoping.
     sleep(SNARE_PAUSE);
+
     // Try as hard as possible not to leave snare processes lurking around after the tests are run,
     // by sending them SIGTERM in as many cases as we reasonably can. Note that `catch_unwind` does
     // not guarantee to catch all panic-y situations, so this can never be perfect.
-    let r = catch_unwind(|| while_running(&sn));
-    kill(Pid::from_raw(sn.id().try_into()?), Signal::SIGTERM)?;
-    if let Err(_) | Ok(Err(_)) = r {
+    let r = catch_unwind(move || {
+        let port = read_to_string(tp.path()).unwrap().parse::<u16>().unwrap();
+
+        let req = req(port).unwrap();
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream.write_all(req.as_bytes()).unwrap();
+        stream.shutdown(Shutdown::Write).unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+
+        // We want to wait for snare to execute any actions that might come with the request. Again, we
+        // have no way of doing that other than waiting and hoping.
+        sleep(SNARE_PAUSE);
+        check_response(response).unwrap();
+    });
+
+    kill(Pid::from_raw(sn.id().try_into().unwrap()), Signal::SIGTERM).unwrap();
+    if r.is_err() {
         let ec = match sn.wait_timeout(SNARE_WAIT_TIMEOUT) {
             Err(e) => e.to_string(),
             Ok(None) => "stalled without exiting".to_owned(),
@@ -62,7 +88,7 @@ where
         let mut stdout = String::new();
         let mut stderr = String::new();
         sn.stdout.as_mut().unwrap().read_to_string(&mut stdout).ok();
-        if stdout.len() > 0 {
+        if !stdout.is_empty() {
             stdout.push('\n');
         }
         sn.stderr.as_mut().unwrap().read_to_string(&mut stderr).ok();
@@ -70,10 +96,10 @@ where
             "snare child process:\n  Exit status: {ec}\n\n  stdout:\n{stdout}\n  stderr:\n{stderr}"
         );
     }
+
     match r {
+        Ok(()) => (),
         Err(r) => resume_unwind(r),
-        Ok(Ok(_)) => (),
-        Ok(Err(e)) => return Err(e),
     }
 
     match sn.wait_timeout(SNARE_WAIT_TIMEOUT) {
@@ -91,28 +117,16 @@ fn exit_success(es: ExitStatus) -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn exit_error(es: ExitStatus) -> Result<(), Box<dyn Error>> {
-    if !es.success() {
-        Ok(())
-    } else {
-        Err(format!("Expected unsuccessful exit but got '{es:?}'").into())
-    }
-}
-
 #[test]
 fn minimal_config() -> Result<(), Box<dyn Error>> {
     run(
-        r#"listen = "127.0.0.1:28083";
+        r#"listen = "127.0.0.1:0";
 github {
 }"#,
+        |_| Ok(String::new()),
         |_| Ok(()),
         exit_success,
     )
-}
-
-#[test]
-fn bad_config() -> Result<(), Box<dyn Error>> {
-    run(r#""#, |_| Ok(()), exit_error)
 }
 
 #[test]
@@ -124,10 +138,23 @@ fn full_request() -> Result<(), Box<dyn Error>> {
     let mut tp = td.path().to_owned();
     tp.push("t");
     let tps = tp.as_path().to_str().unwrap();
+    assert!(!tp.is_file());
     // Example secret and payload from
     // https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#testing-the-webhook-payload-validation
-    let req = r#"POST /payload HTTP/1.1
-Host: 127.0.0.1:28084
+    run(
+        &format!(
+            r#"listen = "127.0.0.1:0";
+github {{
+  match ".*" {{
+    cmd = "touch {tps}";
+    secret = "secretsecret";
+  }}
+}}"#
+        ),
+        move |port| {
+            Ok(format!(
+                r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:{port}
 Content-Length: 104
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
 X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
@@ -138,40 +165,22 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={
-  "repository": {
-    "owner": {
+payload={{
+  "repository": {{
+    "owner": {{
       "login": "testuser"
-    },
+    }},
     "name": "testrepo"
-  }
-}"#;
-
-    run(
-        &format!(
-            r#"listen = "127.0.0.1:28084";
-github {{
-  match ".*" {{
-    cmd = "touch {tps}";
-    secret = "secretsecret";
   }}
 }}"#
-        ),
-        move |_| {
-            assert!(!tp.is_file());
-            let mut stream = TcpStream::connect("127.0.0.1:28084")?;
-            stream.write(req.as_bytes())?;
-            stream.shutdown(Shutdown::Write)?;
-            let mut s = String::new();
-            stream.read_to_string(&mut s)?;
-            if s.starts_with("HTTP/1.1 200 OK") {
-                // We want to wait for snare to fully initialise: there is no way of doing that other than
-                // waiting and hoping.
-                sleep(SNARE_PAUSE);
+            ))
+        },
+        move |response| {
+            if response.starts_with("HTTP/1.1 200 OK") {
                 assert!(tp.is_file());
                 Ok(())
             } else {
-                Err(format!("Received HTTP response '{s}'").into())
+                Err(format!("Received HTTP response '{response}'").into())
             }
         },
         exit_success,
@@ -188,8 +197,23 @@ fn bad_sha256() -> Result<(), Box<dyn Error>> {
     let mut tp = td.path().to_owned();
     tp.push("t");
     let tps = tp.as_path().to_str().unwrap();
-    let req = r#"POST /payload HTTP/1.1
-Host: 127.0.0.1:28084
+    assert!(!tp.is_file());
+    // Example secret and payload from
+    // https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#testing-the-webhook-payload-validation
+    run(
+        &format!(
+            r#"listen = "127.0.0.1:0";
+github {{
+  match ".*" {{
+    cmd = "touch {tps}";
+    secret = "secretsecret";
+  }}
+}}"#
+        ),
+        move |port| {
+            Ok(format!(
+                r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:{port}
 Content-Length: 104
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
 X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde67
@@ -200,40 +224,22 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={
-  "repository": {
-    "owner": {
+payload={{
+  "repository": {{
+    "owner": {{
       "login": "testuser"
-    },
+    }},
     "name": "testrepo"
-  }
-}"#;
-
-    run(
-        &format!(
-            r#"listen = "127.0.0.1:28085";
-github {{
-  match ".*" {{
-    cmd = "touch {tps}";
-    secret = "secretsecret";
   }}
 }}"#
-        ),
-        move |_| {
-            assert!(!tp.is_file());
-            let mut stream = TcpStream::connect("127.0.0.1:28085")?;
-            stream.write(req.as_bytes())?;
-            stream.shutdown(Shutdown::Write)?;
-            let mut s = String::new();
-            stream.read_to_string(&mut s)?;
-            if s.starts_with("HTTP/1.1 400") {
-                // We want to wait for snare to fully initialise: there is no way of doing that other than
-                // waiting and hoping.
-                sleep(SNARE_PAUSE);
+            ))
+        },
+        move |response| {
+            if response.starts_with("HTTP/1.1 400") {
                 assert!(!tp.is_file());
                 Ok(())
             } else {
-                Err(format!("Received HTTP response '{s}'").into())
+                Err(format!("Received HTTP response '{response}'").into())
             }
         },
         exit_success,
@@ -249,10 +255,23 @@ fn wrong_secret() -> Result<(), Box<dyn Error>> {
     let mut tp = td.path().to_owned();
     tp.push("t");
     let tps = tp.as_path().to_str().unwrap();
+    assert!(!tp.is_file());
     // Example secret and payload from
     // https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries#testing-the-webhook-payload-validation
-    let req = r#"POST /payload HTTP/1.1
-Host: 127.0.0.1:28084
+    run(
+        &format!(
+            r#"listen = "127.0.0.1:0";
+github {{
+  match ".*" {{
+    cmd = "touch {tps}";
+    secret = "secretsecretsecret";
+  }}
+}}"#
+        ),
+        move |port| {
+            Ok(format!(
+                r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:{port}
 Content-Length: 104
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
 X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
@@ -263,40 +282,22 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={
-  "repository": {
-    "owner": {
+payload={{
+  "repository": {{
+    "owner": {{
       "login": "testuser"
-    },
+    }},
     "name": "testrepo"
-  }
-}"#;
-
-    run(
-        &format!(
-            r#"listen = "127.0.0.1:28086";
-github {{
-  match ".*" {{
-    cmd = "touch {tps}";
-    secret = "secretsecretsecret";
   }}
 }}"#
-        ),
-        move |_| {
-            assert!(!tp.is_file());
-            let mut stream = TcpStream::connect("127.0.0.1:28086")?;
-            stream.write(req.as_bytes())?;
-            stream.shutdown(Shutdown::Write)?;
-            let mut s = String::new();
-            stream.read_to_string(&mut s)?;
-            if s.starts_with("HTTP/1.1 400") {
-                // We want to wait for snare to fully initialise: there is no way of doing that other than
-                // waiting and hoping.
-                sleep(SNARE_PAUSE);
+            ))
+        },
+        move |response| {
+            if response.starts_with("HTTP/1.1 400") {
                 assert!(!tp.is_file());
                 Ok(())
             } else {
-                Err(format!("Received HTTP response '{s}'").into())
+                Err(format!("Received HTTP response '{response}'").into())
             }
         },
         exit_success,


### PR DESCRIPTION
This PR is overtly about fixing a problem in the new tests, which is that they used fixed port numbers (https://github.com/softdevteam/snare/commit/06a7e8ffc245e0621490f547ccaf28ef2619dc89). Fixing that made it obvious to me where the commonality in tests was, so this PR also cuts down a lot of the boilerplate.