### PR TITLE
Unbreak `ping` support.

### DIFF
--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -188,6 +188,7 @@ fn request(snare: &Arc<Snare>, mut stream: TcpStream) {
     let repo_id = format!("github/{}/{}", owner, repo);
     snare.info(&format!("Received {event_type} for {repo_id}"));
     if event_type == "ping" {
+        http_200(stream);
         return;
     }
 


### PR DESCRIPTION
This didn't return an HTTP result, so github was quite reasonably upset! Add a test so this problem can't recur.