### PR TITLE
Allow `%x` and `%?` to be used in `errorcmd`.

### DIFF
--- a/snare.conf.5
+++ b/snare.conf.5
@@ -117,6 +117,7 @@ the repository.
 a literal
 .Ql % .
 .El
+.Pp
 Note that
 .Ql %
 may not be followed by any character other than those above.
@@ -147,10 +148,24 @@ the repository owner.
 the repository.
 .It Sy %s
 the path to the file containing the job's combined stderr / stdout.
+.It Sy %x
+the exit type:
+.Qq status
+(i.e. normal exit);
+.Qq signal ;
+or
+.Qq unknown .
+.It Sy %?
+the exit status / signal number (either an integer or the literal string
+.Qq unknown )
+that
+.Em cmd
+failed with.
 .It Sy %%
 a literal
 .Ql % .
 .El
+.Pp
 Note that
 .Ql %
 may not be followed by any character other than those above.

--- a/src/config.rs
+++ b/src/config.rs
@@ -289,7 +289,7 @@ impl GitHub {
 
     /// Verify that the `errorcmd` string is valid, returning `Ok())` if so or `Err(String)` if not.
     fn verify_errorcmd_str(errorcmd: &str) -> Result<(), String> {
-        GitHub::verify_str(errorcmd, &['e', 'o', 'r', 'j', 's', '%'])
+        GitHub::verify_str(errorcmd, &['e', 'o', 'r', 'j', 's', '?', 'x', '%'])
     }
 
     fn verify_str(s: &str, modifiers: &[char]) -> Result<(), String> {
@@ -473,7 +473,7 @@ mod test {
     fn test_verify_errorcmd_string() {
         assert!(GitHub::verify_errorcmd_str("").is_ok());
         assert!(GitHub::verify_errorcmd_str("a").is_ok());
-        assert!(GitHub::verify_errorcmd_str("%% %e %o %r %j %s %%").is_ok());
+        assert!(GitHub::verify_errorcmd_str("%% %e %o %r %j %s %x %? %%").is_ok());
         assert!(GitHub::verify_errorcmd_str("%%").is_ok());
         assert!(GitHub::verify_errorcmd_str("%").is_err());
         assert!(GitHub::verify_errorcmd_str("a%").is_err());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,9 +39,17 @@ where
     G: Fn(String) -> Result<(), Box<dyn Error>> + RefUnwindSafe + UnwindSafe + 'static,
 {
     let (mut sn, tp) = snare_command(cfg)?;
-    match sn.try_wait() {
-        Ok(None) => (),
-        _ => todo!(),
+    for i in 0..5 {
+        match sn.try_wait() {
+            Ok(None) => break,
+            _ => {
+                if i < 4 {
+                    sleep(Duration::from_secs(1))
+                } else {
+                    panic!()
+                }
+            }
+        }
     }
     let tp = Rc::new(tp);
 


### PR DESCRIPTION
When `cmd` fails, the only clue as to why can be its exit code. Previously, snare had no way of transmitting this information to the user: this commit allows using `%x` and `%?` (the latter borrowing the similarly named variable from the shell) to in `errorcmd` to access this information.