### PR TITLE
Update README.md with Content Type instructions for github integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,14 @@ about other parts of the file system.
 
 `snare` runs an HTTP server which GitHub can send webhook requests to.
 Configuring a webhook for a given GitHub repository is relatively simple: go to
-that repository, then `Settings > Webhooks > Add webhook`. For `payload`,
-specify `http://yourmachine.com:port/`, specify a `secret` (which you will then
-reuse as the `secret` in `snare.conf`) and then choose which events you wish
-GitHub to deliver. For example, the default `Just the push event` works well
-with the email diff sending per-repo program above, but you can specify
-whichever events you wish.
+that repository, then `Settings > Webhooks > Add webhook`. 
+- For `payload`, specify `http://yourmachine.com:port/`
+- For `Content type`, select `application/x-www-form-urlencoded`
+- Specify a `secret` (which you will then reuse as the `secret` in `snare.conf`)
+
+And then choose which events you wish GitHub to deliver. For example, the default
+`Just the push event` works well with the email diff sending per-repo program above,
+but you can specify whichever events you wish.
 
 Once you have set up your webhook, GitHub will automatically send a test "ping"
 message. `snare` acknowledges pings (i.e. confirms to GitHub that it is


### PR DESCRIPTION
Update docs to reflect that snare supports the Content-type `application/x-www-form-urlencoded`, not `application/json`.

This bit me while setting it up locally. I kept getting _"Payload does not start with 'payload='"_ error messages. When inspecting the test code I [thought it only supported `application/json`](https://github.com/softdevteam/snare/blob/4f94c26bd23b03f9422d610644c449896b9696c5/tests/actions.rs#L56), even though the payload isn't actually json.

Would you want a PR to supporting both `x-www-form-url-encoded` and `json`? It looks like branching on the `Content-Type` header [here](https://github.com/softdevteam/snare/blob/4f94c26bd23b03f9422d610644c449896b9696c5/src/httpserver.rs#L119-L131) would work well.