### PR TITLE
Handle both JSON and urlencoded requests.

### DIFF
--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -49,9 +49,9 @@ github {{
                 Ok(format!(
                     r#"POST /payload HTTP/1.1
 Host: 127.0.0.1:{port}
-Content-Length: 104
+Content-Length: 96
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
-X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
+X-Hub-Signature-256: sha256=d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b2
 User-Agent: GitHub-Hookshot/044aadd
 Content-Type: application/json
 X-GitHub-Event: issues
@@ -59,7 +59,7 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={{
+{{
   "repository": {{
     "owner": {{
       "login": "testuser"
@@ -115,9 +115,9 @@ github {{
                 Ok(format!(
                     r#"POST /payload HTTP/1.1
 Host: 127.0.0.1:{port}
-Content-Length: 104
+Content-Length: 96
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
-X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
+X-Hub-Signature-256: sha256=d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b2
 User-Agent: GitHub-Hookshot/044aadd
 Content-Type: application/json
 X-GitHub-Event: issues
@@ -125,7 +125,7 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={{
+{{
   "repository": {{
     "owner": {{
       "login": "testuser"

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -33,15 +33,15 @@ github {{
 
 fn req(port: u16, good_sha256: bool, event_type: &str) -> String {
     let sha256 = if good_sha256 {
-        "292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66"
+        "d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b2"
     } else {
-        "292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde67"
+        "d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b3"
     };
 
     format!(
         r#"POST /payload HTTP/1.1
 Host: 127.0.0.1:{port}
-Content-Length: 104
+Content-Length: 96
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
 X-Hub-Signature-256: sha256={sha256}
 User-Agent: GitHub-Hookshot/044aadd
@@ -51,7 +51,7 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={{
+{{
   "repository": {{
     "owner": {{
       "login": "testuser"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,100 @@
+use std::error::Error;
+
+mod common;
+use common::run_success;
+
+#[test]
+fn content_type_json() -> Result<(), Box<dyn Error>> {
+    run_success(
+        r#"
+            listen = "127.0.0.1:0";
+            github {
+                match ".*" {
+                    cmd = "true";
+                    secret = "secretsecret";
+                }
+            }
+        "#,
+        &[(
+            move |port| {
+                Ok(format!(
+                    r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:{port}
+Content-Length: 96
+X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
+X-Hub-Signature-256: sha256=d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b2
+User-Agent: GitHub-Hookshot/044aadd
+Content-Type: application/json
+X-GitHub-Event: issues
+X-GitHub-Hook-ID: 292430182
+X-GitHub-Hook-Installation-Target-ID: 79929171
+X-GitHub-Hook-Installation-Target-Type: repository
+
+{{
+  "repository": {{
+    "owner": {{
+      "login": "testuser"
+    }},
+    "name": "testrepo"
+  }}
+}}"#
+                ))
+            },
+            move |response: String| {
+                if response.starts_with("HTTP/1.1 200 OK") {
+                    Ok(())
+                } else {
+                    Err(format!("Received HTTP response '{response}'").into())
+                }
+            },
+        )],
+    )
+}
+
+#[test]
+fn content_type_url_encoded() -> Result<(), Box<dyn Error>> {
+    run_success(
+        r#"
+            listen = "127.0.0.1:0";
+            github {
+                match ".*" {
+                    cmd = "true";
+                    secret = "secretsecret";
+                }
+            }
+        "#,
+        &[(
+            move |port| {
+                Ok(format!(
+                    r#"POST /payload HTTP/1.1
+Host: 127.0.0.1:{port}
+Content-Length: 104
+X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
+X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
+User-Agent: GitHub-Hookshot/044aadd
+Content-Type: application/x-www-form-urlencoded
+X-GitHub-Event: issues
+X-GitHub-Hook-ID: 292430182
+X-GitHub-Hook-Installation-Target-ID: 79929171
+X-GitHub-Hook-Installation-Target-Type: repository
+
+payload={{
+  "repository": {{
+    "owner": {{
+      "login": "testuser"
+    }},
+    "name": "testrepo"
+  }}
+}}"#
+                ))
+            },
+            move |response: String| {
+                if response.starts_with("HTTP/1.1 200 OK") {
+                    Ok(())
+                } else {
+                    Err(format!("Received HTTP response '{response}'").into())
+                }
+            },
+        )],
+    )
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -158,7 +158,7 @@ fn snare_command(cfg: &str) -> Result<(Child, NamedTempFile), Box<dyn Error>> {
     let tp = Builder::new().tempfile_in(env!("CARGO_TARGET_TMPDIR"))?;
     cmd.env("SNARE_DEBUG_PORT_PATH", tp.path().to_str().unwrap());
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    cmd.args(["-d", "-c", tc.path().to_str().unwrap()]);
+    cmd.args(["-d", "-v", "-c", tc.path().to_str().unwrap()]);
     let sn = cmd.spawn()?;
     // We want to wait for snare to fully initialise: there is no way of doing that other than
     // waiting and hoping.

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -23,9 +23,9 @@ fn run_queue(
                 Ok(format!(
                     r#"POST /payload HTTP/1.1
 Host: 127.0.0.1:{port}
-Content-Length: 104
+Content-Length: 96
 X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
-X-Hub-Signature-256: sha256=292e1ce3568fecd98589c71938e19afee9b04b7fe11886d5478d802416bbde66
+X-Hub-Signature-256: sha256=d11297e14fe5286dd68fd58c5e23ea7fb45e60ceff51ec3eb3729400fcbcb4b2
 User-Agent: GitHub-Hookshot/044aadd
 Content-Type: application/json
 X-GitHub-Event: issues
@@ -33,7 +33,7 @@ X-GitHub-Hook-ID: 292430182
 X-GitHub-Hook-Installation-Target-ID: 79929171
 X-GitHub-Hook-Installation-Target-Type: repository
 
-payload={{
+{{
   "repository": {{
     "owner": {{
       "login": "testuser"


### PR DESCRIPTION
I singularly failed to realise that GitHub requests can come with a Content-Type of JSON or urlencoded: previously snare only handled the latter. Handling both automatically is fairly easily, but doing so highlighted that the tests incorrectly said they had JSON content-type but were actually urlencoded. Since JSON content-type is easier to understand, the tests now consistently use that, except for a (new) test to ensure that we really handle urlencoded correctly.

@mweitzel Does this work for your repo(s) on both JSON and urlencoded webhooks?