### PR TITLE
Skip tests that cannot succeed when run as root.

### DIFF
--- a/tests/actions.rs
+++ b/tests/actions.rs
@@ -1,3 +1,4 @@
+use nix::unistd::Uid;
 use std::{fs::read_to_string, thread::sleep};
 use tempfile::Builder;
 
@@ -7,6 +8,11 @@ use common::{run_success, SNARE_PAUSE};
 #[test]
 fn multiple() {
     // This tests that when there are multiple actions, the correct one takes effect.
+
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return;
+    }
 
     let td = Builder::new()
         .tempdir_in(env!("CARGO_TARGET_TMPDIR"))
@@ -88,6 +94,11 @@ X-GitHub-Hook-Installation-Target-Type: repository
 #[test]
 fn errorcmd() {
     // This tests both large stdout/stderr output from `cmd` as well as that `errorcmd` works.
+
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return;
+    }
 
     let td = Builder::new()
         .tempdir_in(env!("CARGO_TARGET_TMPDIR"))

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,3 +1,4 @@
+use nix::unistd::Uid;
 use std::{error::Error, path::PathBuf, thread::sleep};
 use tempfile::{Builder, TempDir};
 
@@ -64,6 +65,10 @@ X-GitHub-Hook-Installation-Target-Type: repository
 
 #[test]
 fn ping() -> Result<(), Box<dyn Error>> {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
     let (cfg, _td, _tp) = cfg(true)?;
     run_success(
         &cfg,
@@ -84,6 +89,11 @@ fn ping() -> Result<(), Box<dyn Error>> {
 fn successful_auth() -> Result<(), Box<dyn Error>> {
     // This test checks that snare both responds to, and executes the correct command for, a given
     // (user, repo) pair. It does that by checking that snare executes `touch <tempfile>`.
+
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
 
     let (cfg, _td, tp) = cfg(true)?;
     assert!(!tp.is_file());
@@ -112,6 +122,11 @@ fn bad_sha256() -> Result<(), Box<dyn Error>> {
     // doesn't execute any commands (so, by proxy, we assume that snare doesn't authenticate the
     // request).
 
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
+
     let (cfg, _td, tp) = cfg(true)?;
     assert!(!tp.is_file());
     // Example secret and payload from
@@ -137,6 +152,11 @@ fn bad_sha256() -> Result<(), Box<dyn Error>> {
 fn wrong_secret() -> Result<(), Box<dyn Error>> {
     // Takes the example from [full_request], alters the client-side secret, and checks that this
     // causes snare not execute any commands (so, by proxy, we assume that authentication failed).
+
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
 
     let (cfg, _td, tp) = cfg(false)?;
     assert!(!tp.is_file());

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,3 +1,4 @@
+use nix::unistd::Uid;
 use std::error::Error;
 
 mod common;
@@ -5,6 +6,11 @@ use common::run_success;
 
 #[test]
 fn content_type_json() -> Result<(), Box<dyn Error>> {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
+
     run_success(
         r#"
             listen = "127.0.0.1:0";
@@ -53,6 +59,11 @@ X-GitHub-Hook-Installation-Target-Type: repository
 
 #[test]
 fn content_type_url_encoded() -> Result<(), Box<dyn Error>> {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
+
     run_success(
         r#"
             listen = "127.0.0.1:0";

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,3 +1,4 @@
+use nix::unistd::Uid;
 use std::error::Error;
 
 mod common;
@@ -5,11 +6,21 @@ use common::{run_preserver_error, run_preserver_success};
 
 #[test]
 fn empty_config() -> Result<(), Box<dyn Error>> {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
+
     run_preserver_error(r#""#)
 }
 
 #[test]
 fn minimal_config() -> Result<(), Box<dyn Error>> {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return Ok(());
+    }
+
     run_preserver_success(
         r#"listen = "127.0.0.1:0";
 github {

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -1,3 +1,4 @@
+use nix::unistd::Uid;
 use std::{error::Error, fs::read_dir, thread::sleep};
 use tempfile::Builder;
 
@@ -80,11 +81,21 @@ github {{
 
 #[test]
 fn sequential() {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return;
+    }
+
     assert_eq!(run_queue("sequential", 20, "", 2).unwrap(), 20);
 }
 
 #[test]
 fn evict() {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return;
+    }
+
     let i = run_queue("evict", 20, "&& sleep 0.4", 4).unwrap();
     // We have a fairly healthy `sleep` above which means most of our requests are likely to be
     // received while the first `cmd` is still running. However, we can't guarantee that, so we are
@@ -99,5 +110,10 @@ fn evict() {
 
 #[test]
 fn parallel() {
+    if Uid::current().is_root() {
+        println!("test skipped: cannot run as root");
+        return;
+    }
+
     assert_eq!(run_queue("parallel", 20, "", 1,).unwrap(), 20);
 }


### PR DESCRIPTION
In general I don't recommend running snare's tests as root, but those running in containers might implicitly be root. In that case, snare's "don't run this as root" check causes things to bork. I would rather preserve that check, so the least worst thing we can do is skip those tests which will definitely fail.